### PR TITLE
Close issue #15

### DIFF
--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresTIDResponseAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresTIDResponseAction.java
@@ -80,7 +80,7 @@ public class PostgresTIDResponseAction extends BaseRestHandler {
             // and then change what our request looks like so it'll appear
             // as if the json version is the actual content
             long parseStart = System.nanoTime();
-            query = buildJsonQueryFromRequestContent(client, request, false, false);
+            query = buildJsonQueryFromRequestContent(client, request, false, "data".equals(request.param("type")));
             long parseEnd = System.nanoTime();
 
             request = new OverloadedContentRestRequest(request, new BytesArray(query.getQuery()));

--- a/postgres/src/main/c/am/elasticsearch.h
+++ b/postgres/src/main/c/am/elasticsearch.h
@@ -28,7 +28,7 @@ void elasticsearch_refreshIndex(ZDBIndexDescriptor *indexDescriptor);
 uint64             elasticsearch_actualIndexRecordCount(ZDBIndexDescriptor *indexDescriptor, char *type_name);
 uint64             elasticsearch_estimateCount(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char **queries, int nqueries);
 ZDBSearchResponse *elasticsearch_searchIndex(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char **queries, int nqueries, uint64 *nhits);
-ZDBSearchResponse *elasticsearch_getAllItems(ZDBIndexDescriptor *indexDescriptor, uint64 *nitems);
+ZDBSearchResponse *elasticsearch_getPossiblyExpiredItems(ZDBIndexDescriptor *indexDescriptor, uint64 *nitems);
 
 char *elasticsearch_tally(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char *fieldname, char *stem, char *query, int64 max_terms, char *sort_order);
 char *elasticsearch_significant_terms(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char *fieldname, char *stem, char *query, int64 max_terms);
@@ -43,7 +43,7 @@ char *elasticsearch_highlight(ZDBIndexDescriptor *indexDescriptor, char *query, 
 
 void elasticsearch_freeSearchResponse(ZDBSearchResponse *searchResponse);
 
-void elasticsearch_bulkDelete(ZDBIndexDescriptor *indexDescriptor, ItemPointerData *items, int nitems);
+void elasticsearch_bulkDelete(ZDBIndexDescriptor *indexDescriptor, List *itemPointers, int nitems);
 
 void elasticsearch_batchInsertRow(ZDBIndexDescriptor *indexDescriptor, ItemPointer ctid, TransactionId xmin, TransactionId xmax, CommandId cmin, CommandId cmax, bool xmin_is_committed, bool xmax_is_committed, text *data);
 void elasticsearch_batchInsertFinish(ZDBIndexDescriptor *indexDescriptor);

--- a/postgres/src/main/c/am/zdb_interface.h
+++ b/postgres/src/main/c/am/zdb_interface.h
@@ -151,7 +151,7 @@ typedef void (*ZDBRefreshIndex_function)(ZDBIndexDescriptor *indexDescriptor);
 typedef uint64 (*ZDBActualIndexRecordCount_function)(ZDBIndexDescriptor *indexDescriptor, char *table_name);
 typedef uint64 (*ZDBEstimateCount_function)(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char **queries, int nqueries);
 typedef ZDBSearchResponse *(*ZDBSearchIndex_function)(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char **queries, int nqueries, uint64 *nhits);
-typedef ZDBSearchResponse *(*ZDBGetAllItems_function)(ZDBIndexDescriptor *indexDescriptor, uint64 *nitems);
+typedef ZDBSearchResponse *(*ZDBGetPossiblyExpiredItems)(ZDBIndexDescriptor *indexDescriptor, uint64 *nitems);
 
 typedef char *(*ZDBTally_function)(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char *fieldname, char *stem, char *query, int64 max_terms, char *sort_order);
 typedef char *(*ZDBSignificantTerms_function)(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char *fieldname, char *stem, char *query, int64 max_terms);
@@ -166,7 +166,7 @@ typedef char *(*ZDBHighlight_function)(ZDBIndexDescriptor *indexDescriptor, char
 
 typedef void (*ZDBFreeSearchResponse_function)(ZDBSearchResponse *searchResponse);
 
-typedef void (*ZDBBulkDelete_function)(ZDBIndexDescriptor *indexDescriptor, ItemPointerData *items, int nitems);
+typedef void (*ZDBBulkDelete_function)(ZDBIndexDescriptor *indexDescriptor, List *itemPointers, int nitems);
 
 typedef void (*ZDBIndexBatchInsertRow_function)(ZDBIndexDescriptor *indexDescriptor, ItemPointer ctid, TransactionId xmin, TransactionId xmax, CommandId cmin, CommandId cmax, bool xmin_is_committed, bool xmax_is_committed, text *data);
 typedef void (*ZDBIndexBatchInsertFinish_function)(ZDBIndexDescriptor *indexDescriptor);
@@ -186,7 +186,7 @@ struct ZDBIndexImplementation
 	ZDBActualIndexRecordCount_function actualIndexRecordCount;
 	ZDBEstimateCount_function estimateCount;
 	ZDBSearchIndex_function   searchIndex;
-	ZDBGetAllItems_function   getAllItems;
+	ZDBGetPossiblyExpiredItems getPossiblyExpiredItems;
 
 	ZDBTally_function              tally;
 	ZDBSignificantTerms_function   significant_terms;


### PR DESCRIPTION
First, we only test rows for deletion that might actually be dead (_xmax_is_committed:true or _xmin_is_committed:false).  This reduces the total number of rows we need to examine to what's likely the complete set, rather than needing to inspect each and every row in the index.  So instead of looking at 20M+ rows, we just look at the 50k that have been UPDATEd or DELETEd.

Secondly, when building the internal set of ItemPointers to actually delete, use a `List` instead of manually growing/copying a `char *`.

This also renames the "getAllItems" function to "getPossiblyExpiredItems" because that's what it does, and "get all items" isn't a thing we do anywhere.