### PR TITLE
fix issue #29:  Use the "max_terms" value for tally aggregate function

### DIFF
--- a/SQL-API.md
+++ b/SQL-API.md
@@ -278,7 +278,7 @@ These custom domains are to be used in user tables as data types when you requir
 > ```fieldname```: The name of a field from which to derive significant terms  
 > ```stem```:  a Regular expression by which to filter returned terms   
 > ```query```: a full text query  
-> ```max_terms```: maximum number of terms to return
+> ```max_terms```: maximum number of terms to return.  A value of zero means "all terms".
 > 
 > This function provides direct access to Elasticsearch's ["significant terms"](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html) aggregation.  The results are MVCC-safe.  Returned terms are forced to upper-case.
 > 
@@ -297,7 +297,7 @@ These custom domains are to be used in user tables as data types when you requir
 > ```fieldname```: The name of a field from which to derive term suggestions  
 > ```base```:  a word from which suggestions will be created   
 > ```query```: a full text query  
-> ```max_terms```: maximum number of terms to return
+> ```max_terms```: maximum number of terms to return.  A value of zero means "all terms".
 > 
 > This function provides direct access to Elasticsearch's [term suggester](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-term.html) and unlike zdb_significant_terms and zdb_tally, **can** be used with fields of type ```phrase```, ```phrase_array```, and ```fulltext```.  The results are MVCC-safe.  Returned terms are forced to upper-case.
 > 
@@ -322,7 +322,7 @@ These custom domains are to be used in user tables as data types when you requir
 > ```fieldname```: The name of a field from which to derive terms  
 > ```stem```:  a Regular expression by which to filter returned terms   
 > ```query```: a full text query  
-> ```max_terms```: maximum number of terms to return
+> ```max_terms```: maximum number of terms to return.  A value of zero means "all terms".
 > ```sort_order```: how to sort the terms.  one of ```'count'```, ```'term'```, ```'reverse_count'```, ```'reverse_term'```
 > 
 > This function provides direct access to Elasticsearch's [terms aggregate](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) and cannot be used with fields of type ```phrase```, ```phrase_array```, and ```fulltext```.  The results are MVCC-safe.  Returned terms are forced to upper-case.

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/QueryRewriter.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/QueryRewriter.java
@@ -1,5 +1,6 @@
 /*
- * Copyright 2013-2015 Technology Concepts & Design, Inc
+ * Portions Copyright 2013-2015 Technology Concepts & Design, Inc
+ * Portions Copyright 2015 ZomboDB, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -362,7 +363,7 @@ public class QueryRewriter {
         } else {
             TermsBuilder tb = terms(agg.getFieldname())
                     .field(fieldname)
-                    .size(0) //agg.getMaxTerms())
+                    .size(agg.getMaxTerms())
                     .shardSize(0)
                     .order(stringToTermsOrder(agg.getSortOrder()));
 

--- a/postgres/src/test/expected/issue-29.out
+++ b/postgres/src/test/expected/issue-29.out
@@ -1,0 +1,16 @@
+SELECT * FROM zdb_tally('so_posts', 'owner_display_name', '^.*', '', 10, 'count');
+   term    | count  
+-----------+--------
+           | 154132
+ USER1249  |    598
+ USER2567  |    513
+ USER8685  |    254
+ USER4051  |    153
+ USER8     |     84
+ USER29981 |     79
+ USER39685 |     68
+ USER23157 |     50
+ SERGIO    |     48
+ USER29079 |     47
+(11 rows)
+

--- a/postgres/src/test/sql/issue-29.sql
+++ b/postgres/src/test/sql/issue-29.sql
@@ -1,0 +1,1 @@
+SELECT * FROM zdb_tally('so_posts', 'owner_display_name', '^.*', '', 10, 'count');

--- a/postgres/src/test/tests.list
+++ b/postgres/src/test/tests.list
@@ -32,3 +32,4 @@ syntax-complex_query
 issue-7
 issue-11
 issue-13
+issue-29


### PR DESCRIPTION
QueryRewriter.java was hardcoding zero as the .size() argument to the TermsBuilder, which means "get everything".  This change sets it to the value provided by the user in their call to zdb_tally().  A user-provided value of zero now means "get everything".

The .shardSize() argument is still hardcoded to zero, which means that ES will be as precise as it possibly can when pulling terms from each shard.

Thanks to @ryancutter for the report and discussion.

Also:
  - Aggregation execution time logging was stupidly logging before the aggregate actually finished.
  - a test to make sure results from zdb_tally() are indeed limited by the 'max_terms' argument.