### PR TITLE
Search many tables at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 target/
 .DS_store
 foo.*
-postgres/src/main/sql/zombodb--2.5.6.sql
+postgres/src/main/sql/zombodb--2.5.7.sql
 postgres/src/test/sql/setup.sql
 postgres/src/test/sql/so_comments.sql
 postgres/results

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Elasticsearch-calculated aggregations are also provided through custom functions
   - range queries
   - term/phrase boosting
 - query results expansion and index linking
+- search across multiple tables at once
 - high-performance hit highlighting
 - access to many of Elasticsearch's aggregations, including ability to nest aggregations
 - use whatever method you currently use for talking to Postgres (JDBC, DBI, libpq, etc)

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -9,7 +9,7 @@
 FROM java:7
 
 ENV ES_PKG_NAME elasticsearch-1.7.1
-ENV ZOMBODB_VER 2.5.6
+ENV ZOMBODB_VER 2.5.7
 
 # Install Elasticsearch.
 RUN \

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -4,7 +4,7 @@
 
 # Pull base image.
 FROM postgres:9.3
-ENV ZOMBODB_VER 2.5.6
+ENV ZOMBODB_VER 2.5.7
 
 # Fetch wget
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/*

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.tcdi.elasticsearch</groupId>
         <artifactId>zombodb-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
 
     <artifactId>zombodb-plugin</artifactId>

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/ZombodbPlugin.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/ZombodbPlugin.java
@@ -38,6 +38,7 @@ public class ZombodbPlugin extends AbstractPlugin {
         module.addRestAction(PostgresMappingAction.class);
         module.addRestAction(ZombodbQueryAction.class);
         module.addRestAction(ZombodbDocumentHighlighterAction.class);
+        module.addRestAction(ZombodbMultisearchAction.class);
     }
 
     @Override

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/ZombodbMultisearchAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/ZombodbMultisearchAction.java
@@ -1,0 +1,90 @@
+package com.tcdi.zombodb.postgres;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tcdi.zombodb.query_parser.QueryRewriter;
+import org.elasticsearch.action.search.MultiSearchRequestBuilder;
+import org.elasticsearch.action.search.MultiSearchResponse;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.support.RestToXContentListener;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+/**
+ * Created by e_ridge on 12/17/15.
+ */
+public class ZombodbMultisearchAction extends BaseRestHandler {
+
+    public static class MultisearchDescriptor {
+        private String indexName;
+        private String query;
+        private String preference;
+        private String pkey;
+
+        public String getIndexName() {
+            return indexName;
+        }
+
+        public void setIndexName(String indexName) {
+            this.indexName = indexName;
+        }
+
+        public String getQuery() {
+            return query;
+        }
+
+        public void setQuery(String query) {
+            this.query = query;
+        }
+
+        public String getPreference() {
+            return preference;
+        }
+
+        public void setPreference(String preference) {
+            this.preference = preference;
+        }
+
+        public String getPkey() {
+            return pkey;
+        }
+
+        public void setPkey(String pkey) {
+            this.pkey = pkey;
+        }
+    }
+
+    @Inject
+    protected ZombodbMultisearchAction(Settings settings, RestController controller, Client client) {
+        super(settings, controller, client);
+        controller.registerHandler(GET, "/{index}/{type}/_zdbmsearch", this);
+        controller.registerHandler(POST, "/{index}/{type}/_zdbmsearch", this);
+    }
+
+    @Override
+    protected void handleRequest(RestRequest request, RestChannel channel, Client client) throws Exception {
+        MultisearchDescriptor[] descriptors = new ObjectMapper().readValue(request.content().streamInput(), MultisearchDescriptor[].class);
+        MultiSearchRequestBuilder msearchBuilder = new MultiSearchRequestBuilder(client);
+        String thisType = request.param("type");
+
+        for (MultisearchDescriptor md : descriptors) {
+            SearchRequestBuilder srb = new SearchRequestBuilder(client);
+
+            srb.setIndices(md.getIndexName());
+            srb.setTypes(thisType);
+            if (md.getPkey() != null) srb.addFieldDataField(md.getPkey());
+            srb.setQuery(new QueryRewriter(client, md.getIndexName(), md.getPreference(), md.getQuery(), true, true).rewriteQuery());
+
+            msearchBuilder.add(srb);
+        }
+
+        client.multiSearch(msearchBuilder.request(), new RestToXContentListener<MultiSearchResponse>(channel));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.tcdi.elasticsearch</groupId>
     <artifactId>zombodb-parent</artifactId>
-    <version>2.5.6</version>
+    <version>2.5.7</version>
 
     <packaging>pom</packaging>
 

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.tcdi.elasticsearch</groupId>
         <artifactId>zombodb-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.5.7</version>
     </parent>
 
     <artifactId>zombodb</artifactId>

--- a/postgres/src/main/c/am/elasticsearch.h
+++ b/postgres/src/main/c/am/elasticsearch.h
@@ -25,6 +25,9 @@ void elasticsearch_updateMapping(ZDBIndexDescriptor *indexDescriptor, char *mapp
 void elasticsearch_dropIndex(ZDBIndexDescriptor *indexDescriptor);
 void elasticsearch_refreshIndex(ZDBIndexDescriptor *indexDescriptor);
 
+char *elasticsearch_multi_search(ZDBIndexDescriptor **descriptors, TransactionId xid, CommandId cid, char **user_queries, int nqueries);
+
+
 uint64             elasticsearch_actualIndexRecordCount(ZDBIndexDescriptor *indexDescriptor, char *type_name);
 uint64             elasticsearch_estimateCount(ZDBIndexDescriptor *indexDescriptor, TransactionId xid, CommandId cid, char **queries, int nqueries);
 uint64             elasticsearch_estimateSelectivity(ZDBIndexDescriptor *indexDescriptor, char *query);

--- a/postgres/src/main/c/am/zdb_interface.c
+++ b/postgres/src/main/c/am/zdb_interface.c
@@ -270,6 +270,20 @@ void zdb_transaction_finish(void)
 }
 
 
+char *zdb_multi_search(TransactionId xid, CommandId cid, Oid *indexrelids, char **user_queries, int nqueries) {
+	int i;
+	ZDBIndexDescriptor **descriptors = (ZDBIndexDescriptor **) palloc(nqueries * (sizeof (ZDBIndexDescriptor*)));
+
+	for (i=0; i<nqueries; i++) {
+		descriptors[i] = zdb_alloc_index_descriptor_by_index_oid(indexrelids[i]);
+
+		if (!descriptors[i])
+			elog(ERROR, "Unable to create ZDBIndexDescriptor for index oid %d", indexrelids[i]);
+	}
+
+	return elasticsearch_multi_search(descriptors, xid, cid, user_queries, nqueries);
+}
+
 
 /** implementation wrapper functions */
 

--- a/postgres/src/main/c/am/zdb_interface.h
+++ b/postgres/src/main/c/am/zdb_interface.h
@@ -118,7 +118,7 @@ typedef struct
 	ZDBIndexDescriptor    *desc;
 
 	ItemPointer ctid;
-}                                     ZDBCommitXactData;
+} ZDBCommitXactData;
 
 typedef struct
 {
@@ -153,6 +153,8 @@ ZDBIndexDescriptor *zdb_alloc_index_descriptor_by_index_oid(Oid indexrelid);
 void               zdb_free_index_descriptor(ZDBIndexDescriptor *indexDescriptor);
 ZDBCommitXactData  *zdb_alloc_new_xact_record(ZDBIndexDescriptor *indexDescriptor, ItemPointer ctid);
 ZDBCommitXactData  *zdb_alloc_expired_xact_record(ZDBIndexDescriptor *indexDescriptor, ItemPointer ctid, TransactionId xmax, CommandId cmax);
+
+char *zdb_multi_search(TransactionId xid, CommandId cid, Oid *indexrelids, char **user_queries, int nqueries);
 
 bool zdb_index_descriptors_equal(ZDBIndexDescriptor *a, ZDBIndexDescriptor *b);
 

--- a/postgres/src/main/c/am/zdbops.h
+++ b/postgres/src/main/c/am/zdbops.h
@@ -35,6 +35,7 @@ extern Datum zdb_internal_describe_nested_object(PG_FUNCTION_ARGS);
 extern Datum zdb_internal_get_index_mapping(PG_FUNCTION_ARGS);
 extern Datum zdb_internal_get_index_field_lists(PG_FUNCTION_ARGS);
 extern Datum zdb_internal_highlight(PG_FUNCTION_ARGS);
+extern Datum zdb_internal_multi_search(PG_FUNCTION_ARGS);
 
 extern Datum make_es_mapping(TupleDesc tupdesc, bool isAnonymous);
 

--- a/postgres/src/main/c/util/zdbutils.h
+++ b/postgres/src/main/c/util/zdbutils.h
@@ -18,11 +18,14 @@
 
 #include "postgres.h"
 #include "lib/stringinfo.h"
+#include "utils/array.h"
 
 #define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
 
 void appendBinaryStringInfoAndStripLineBreaks(StringInfo str, const char *data, int datalen);
 void freeStringInfo(StringInfo si);
 char *lookup_primary_key(char *schemaName, char *tableName, bool failOnMissing);
+Oid *oid_array_to_oids(ArrayType *arr, int *many);
+char **text_array_to_strings(ArrayType *array, int *many);
 
 #endif

--- a/postgres/src/main/sql/zombodb--2.5.6--2.5.7.sql
+++ b/postgres/src/main/sql/zombodb--2.5.6--2.5.7.sql
@@ -1,1 +1,42 @@
--- no sql changes
+CREATE TYPE zdb_multi_search_response AS (table_name regclass, query text, total int8, ctid tid, score float4, row_data json);
+
+CREATE OR REPLACE FUNCTION zdb_id_to_ctid(id text) RETURNS tid LANGUAGE sql STRICT IMMUTABLE AS $$
+SELECT ('(' || replace(id, '-', ',') || ')')::tid;
+$$;
+
+CREATE OR REPLACE FUNCTION zdb_extract_table_row(table_name regclass, row_ctid tid) RETURNS json LANGUAGE plpgsql STRICT IMMUTABLE AS $$
+DECLARE
+   real_table_name regclass;
+   row_data json;
+BEGIN
+   SELECT indrelid::regclass INTO real_table_name FROM pg_index WHERE indexrelid = zdb_determine_index(table_name);
+   EXECUTE format('SELECT row_to_json(x) FROM (SELECT %s, ctid FROM %s) x WHERE ctid = ''%s''',
+                  (select array_to_string(array_agg(attname), ',') from pg_attribute where attrelid = table_name and atttypid <> 'fulltext'::regtype and not attisdropped and attnum >=0),
+                  real_table_name,
+                  row_ctid) INTO row_data;
+   RETURN row_data;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION zdb_internal_multi_search(table_names oid[], queries text[]) RETURNS json LANGUAGE c STRICT IMMUTABLE AS '$libdir/plugins/zombodb';
+CREATE OR REPLACE FUNCTION zdb_multi_search(table_names regclass[], queries text[]) RETURNS SETOF zdb_multi_search_response LANGUAGE plpgsql STRICT IMMUTABLE AS $$
+DECLARE
+  response json;
+  many integer;
+BEGIN
+  response := zdb_internal_multi_search((SELECT array_agg(zdb_determine_index(unnest)) FROM unnest(table_names)), queries)->'responses';
+  many := array_upper(table_names, 1);
+
+  RETURN QUERY SELECT
+                 table_names[gs],
+                 queries[gs],
+                 (json_array_element(response, gs - 1)->'hits'->>'total')::int8,
+                 zdb_id_to_ctid(json_array_elements(json_array_element(response, gs - 1)->'hits'->'hits')->> '_id')::tid,
+                 (json_array_elements(json_array_element(response, gs-1)->'hits'->'hits')->>'_score')::float4,
+                 zdb_extract_table_row(table_names[gs], zdb_id_to_ctid(json_array_elements(json_array_element(response, gs - 1)->'hits'->'hits')->>'_id')::tid)
+                FROM generate_series(1, many) gs;
+END;
+$$;
+CREATE OR REPLACE FUNCTION zdb_multi_search(table_names regclass[], query text) RETURNS SETOF zdb_multi_search_response LANGUAGE sql STRICT IMMUTABLE AS $$
+  SELECT * FROM zdb_multi_search($1, (SELECT array_agg($2) FROM unnest(table_names)));
+$$;

--- a/postgres/src/main/sql/zombodb--2.5.6--2.5.7.sql
+++ b/postgres/src/main/sql/zombodb--2.5.6--2.5.7.sql
@@ -1,0 +1,1 @@
+-- no sql changes

--- a/postgres/src/main/sql/zombodb.sql
+++ b/postgres/src/main/sql/zombodb.sql
@@ -415,6 +415,50 @@ BEGIN
 END;
 $$;
 
+
+
+CREATE TYPE zdb_multi_search_response AS (table_name regclass, query text, total int8, ctid tid, score float4, row_data json);
+CREATE OR REPLACE FUNCTION zdb_id_to_ctid(id text) RETURNS tid LANGUAGE sql STRICT IMMUTABLE AS $$
+SELECT ('(' || replace(id, '-', ',') || ')')::tid;
+$$;
+CREATE OR REPLACE FUNCTION zdb_extract_table_row(table_name regclass, row_ctid tid) RETURNS json LANGUAGE plpgsql STRICT IMMUTABLE AS $$
+DECLARE
+  real_table_name regclass;
+  row_data json;
+BEGIN
+  SELECT indrelid::regclass INTO real_table_name FROM pg_index WHERE indexrelid = zdb_determine_index(table_name);
+  EXECUTE format('SELECT row_to_json(x) FROM (SELECT %s, ctid FROM %s) x WHERE ctid = ''%s''',
+                 (select array_to_string(array_agg(attname), ',') from pg_attribute where attrelid = table_name and atttypid <> 'fulltext'::regtype and not attisdropped and attnum >=0),
+                 real_table_name,
+                 row_ctid) INTO row_data;
+  RETURN row_data;
+END;
+$$;
+CREATE OR REPLACE FUNCTION zdb_internal_multi_search(table_names oid[], queries text[]) RETURNS json LANGUAGE c STRICT IMMUTABLE AS '$libdir/plugins/zombodb';
+CREATE OR REPLACE FUNCTION zdb_multi_search(table_names regclass[], queries text[]) RETURNS SETOF zdb_multi_search_response LANGUAGE plpgsql STRICT IMMUTABLE AS $$
+DECLARE
+  response json;
+  many integer;
+BEGIN
+  response := zdb_internal_multi_search((SELECT array_agg(zdb_determine_index(unnest)) FROM unnest(table_names)), queries)->'responses';
+  many := array_upper(table_names, 1);
+
+  RETURN QUERY SELECT
+                 table_names[gs],
+                 queries[gs],
+                 (json_array_element(response, gs - 1)->'hits'->>'total')::int8,
+                 zdb_id_to_ctid(json_array_elements(json_array_element(response, gs - 1)->'hits'->'hits')->> '_id')::tid,
+                 (json_array_elements(json_array_element(response, gs-1)->'hits'->'hits')->>'_score')::float4,
+                 zdb_extract_table_row(table_names[gs], zdb_id_to_ctid(json_array_elements(json_array_element(response, gs - 1)->'hits'->'hits')->>'_id')::tid)
+               FROM generate_series(1, many) gs;
+END;
+$$;
+CREATE OR REPLACE FUNCTION zdb_multi_search(table_names regclass[], query text) RETURNS SETOF zdb_multi_search_response LANGUAGE sql STRICT IMMUTABLE AS $$
+SELECT * FROM zdb_multi_search($1, (SELECT array_agg($2) FROM unnest(table_names)));
+$$;
+
+
+
 DO LANGUAGE plpgsql $$
 BEGIN
     PERFORM * FROM pg_am WHERE amname = 'zombodb';

--- a/postgres/src/test/expected/multi-search.out
+++ b/postgres/src/test/expected/multi-search.out
@@ -1,0 +1,35 @@
+select table_name, query, total from zdb_multi_search(ARRAY['so_posts', 'so_users', 'words'], 'cheese');
+ table_name | query  | total 
+------------+--------+-------
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_posts   | cheese |    48
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ so_users   | cheese |    19
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+ words      | cheese |    54
+(30 rows)
+

--- a/postgres/src/test/sql/multi-search.sql
+++ b/postgres/src/test/sql/multi-search.sql
@@ -1,0 +1,1 @@
+select table_name, query, total from zdb_multi_search(ARRAY['so_posts', 'so_users', 'words'], 'cheese');

--- a/postgres/src/test/tests.list
+++ b/postgres/src/test/tests.list
@@ -55,3 +55,4 @@ issue-66
 syntax-ASTArrayData
 issue-68
 get-field-lists
+multi-search

--- a/postgres/zombodb.control
+++ b/postgres/zombodb.control
@@ -1,6 +1,6 @@
 # zombodb extension
 comment = 'Elasticsearch-enabled Index Type for Postgres 9.3'
-default_version = '2.5.6'
+default_version = '2.5.7'
 module_pathname = '$libdir/zombodb'
 relocatable = true
 requires = ''


### PR DESCRIPTION
This pull request implements functionality to search multiple tables at the same time.  The tables can either be searched with the same query, or each searched with different queries.  The results include the "top 10" (ordered by score desc) matching documents from each table (including partial `row_to_json()` data).

The returned row data purposely omits any columns of type `fulltext` for performance reasons -- testing showed that including these would make the total execution time over 20x slower.  This seems like a fair compromise as if you're searching multiple tables at a time, you likely only want to show the user a summary of what was found.

SQL-level functions exist for searching an array of tables/views with the same query, or searching an array of tables/views each with their own query.

The backend implementation detail is that this is implemented using Elasticsearch's [Multi Search API](https://www.elastic.co/guide/en/elasticsearch/reference/1.4/search-multi-search.html), so it should be as efficient as possible.

Also updates the version to 2.5.7
