### PR TITLE
resolving issue #91:

### DIFF
--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresAggregationAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresAggregationAction.java
@@ -56,7 +56,7 @@ public class PostgresAggregationAction extends BaseRestHandler {
             final long start = System.currentTimeMillis();
             SearchRequestBuilder builder = new SearchRequestBuilder(client);
             String input = request.content().toUtf8();
-            final QueryRewriter rewriter = new QueryRewriter(client, request.param("index"), request.param("preference"), input, true, false, true, false);
+            final QueryRewriter rewriter = new QueryRewriter(client, request.param("index"), request.param("preference"), input, true, false, true, false, true);
             QueryBuilder qb = rewriter.rewriteQuery();
             AbstractAggregationBuilder ab = rewriter.rewriteAggregations();
             SuggestBuilder.SuggestionBuilder tsb = rewriter.rewriteSuggestions();
@@ -78,6 +78,7 @@ public class PostgresAggregationAction extends BaseRestHandler {
             builder.setNoFields();
             builder.setSearchType(SearchType.COUNT);
             builder.setPreference(request.param("preference"));
+            builder.setQueryCache(true);
 
             final ActionListener<SearchResponse> delegate = new RestStatusToXContentListener<SearchResponse>(channel);
             client.search(builder.request(), new ActionListener<SearchResponse>() {

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresCountAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresCountAction.java
@@ -53,7 +53,7 @@ public class PostgresCountAction extends BaseRestHandler {
             SearchRequest searchRequest;
             QueryAndIndexPair query;
 
-            query = PostgresTIDResponseAction.buildJsonQueryFromRequestContent(client, request, false, !isSelectivityQuery);
+            query = PostgresTIDResponseAction.buildJsonQueryFromRequestContent(client, request, false, !isSelectivityQuery, !isSelectivityQuery);
             request = new OverloadedContentRestRequest(request, new BytesArray(query.getQuery()));
             request.params().put("index", query.getIndexName());
             request.params().put("type", "data");
@@ -65,6 +65,7 @@ public class PostgresCountAction extends BaseRestHandler {
             searchRequest.listenerThreaded(false);
             searchRequest.searchType(SearchType.COUNT);
             searchRequest.preference(request.param("preference"));
+            searchRequest.queryCache(true);
 
 
             SearchResponse searchResponse = client.search(searchRequest).get();

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresMappingAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresMappingAction.java
@@ -43,7 +43,7 @@ public class PostgresMappingAction extends BaseRestHandler {
     protected void handleRequest(RestRequest request, RestChannel channel, Client client) throws Exception {
         BytesRestResponse response;
 
-        QueryRewriter rewriter = new QueryRewriter(client, request.param("index"), request.param("preference"), request.content().toUtf8(), false, true);
+        QueryRewriter rewriter = new QueryRewriter(client, request.param("index"), request.param("preference"), request.content().toUtf8(), false, true, true);
         rewriter.rewriteQuery();
         Map<String, ?> properties = rewriter.describedNestedObject(request.param("fieldname"));
 

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresTIDResponseAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/PostgresTIDResponseAction.java
@@ -80,7 +80,7 @@ public class PostgresTIDResponseAction extends BaseRestHandler {
             // and then change what our request looks like so it'll appear
             // as if the json version is the actual content
             long parseStart = System.nanoTime();
-            query = buildJsonQueryFromRequestContent(client, request, false, "data".equals(request.param("type")));
+            query = buildJsonQueryFromRequestContent(client, request, false, "data".equals(request.param("type")), true);
             long parseEnd = System.nanoTime();
 
             request = new OverloadedContentRestRequest(request, new BytesArray(query.getQuery()));
@@ -96,6 +96,7 @@ public class PostgresTIDResponseAction extends BaseRestHandler {
             searchRequest.scroll(TimeValue.timeValueMinutes(10));
             searchRequest.searchType(SearchType.SCAN);
             searchRequest.preference(request.param("preference"));
+            searchRequest.queryCache(true);
 
             final long searchStart = System.currentTimeMillis();
             response = client.search(searchRequest).get();
@@ -115,11 +116,11 @@ public class PostgresTIDResponseAction extends BaseRestHandler {
         }
     }
 
-    public static QueryAndIndexPair buildJsonQueryFromRequestContent(Client client, RestRequest request, boolean allowSingleIndex, boolean useParentChild) {
+    public static QueryAndIndexPair buildJsonQueryFromRequestContent(Client client, RestRequest request, boolean allowSingleIndex, boolean useParentChild, boolean doFullFieldDataLookups) {
         String query = request.content().toUtf8();
 
         try {
-            QueryRewriter qr = new QueryRewriter(client, request.param("index"), request.param("preference"), query, allowSingleIndex, useParentChild);
+            QueryRewriter qr = new QueryRewriter(client, request.param("index"), request.param("preference"), query, allowSingleIndex, useParentChild, doFullFieldDataLookups);
             String indexName;
 
             // the request content is just our straight query string

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/ZombodbMultiSearchAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/ZombodbMultiSearchAction.java
@@ -82,7 +82,7 @@ public class ZombodbMultiSearchAction extends BaseRestHandler {
             srb.setIndices(md.getIndexName());
             srb.setTypes(thisType);
             if (md.getPkey() != null) srb.addFieldDataField(md.getPkey());
-            srb.setQuery(new QueryRewriter(client, md.getIndexName(), md.getPreference(), md.getQuery(), true, true).rewriteQuery());
+            srb.setQuery(new QueryRewriter(client, md.getIndexName(), md.getPreference(), md.getQuery(), true, true, true).rewriteQuery());
 
             msearchBuilder.add(srb);
         }

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/ZombodbQueryAction.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/postgres/ZombodbQueryAction.java
@@ -49,7 +49,7 @@ public class ZombodbQueryAction extends BaseRestHandler {
                 QueryRewriter qr;
                 String json;
 
-                qr = new QueryRewriter(client, request.param("index"), request.param("preference"), query, false, true);
+                qr = new QueryRewriter(client, request.param("index"), request.param("preference"), query, false, true, true);
                 json = qr.rewriteQuery().toString();
 
                 response = new BytesRestResponse(RestStatus.OK, "application/json", json);

--- a/elasticsearch/src/test/java/com/tcdi/zombodb/test/ZomboDBTestCase.java
+++ b/elasticsearch/src/test/java/com/tcdi/zombodb/test/ZomboDBTestCase.java
@@ -125,7 +125,7 @@ public abstract class ZomboDBTestCase {
     }
 
     protected QueryRewriter qr(String query, boolean useParentChild) {
-        return new QueryRewriter(client(), DEFAULT_INDEX_NAME, null, query, false, useParentChild) {
+        return new QueryRewriter(client(), DEFAULT_INDEX_NAME, null, query, false, useParentChild, true) {
             @Override
             protected boolean isInTestMode() {
                 return true;

--- a/postgres/src/main/c/am/zdb_interface.h
+++ b/postgres/src/main/c/am/zdb_interface.h
@@ -159,6 +159,7 @@ ZDBCommitXactData  *zdb_alloc_expired_xact_record(ZDBIndexDescriptor *indexDescr
 char *zdb_multi_search(TransactionId xid, CommandId cid, Oid *indexrelids, char **user_queries, int nqueries);
 
 bool zdb_index_descriptors_equal(ZDBIndexDescriptor *a, ZDBIndexDescriptor *b);
+void interface_transaction_cleanup(void);
 
 
 /**
@@ -203,6 +204,9 @@ typedef void (*ZDBTransactionFinish_function)(ZDBIndexDescriptor *indexDescripto
 
 struct ZDBIndexImplementation
 {
+	uint64 _last_selectivity_value;
+	char *_last_selectivity_query;
+
 	ZDBCreateNewIndex_function   createNewIndex;
 	ZDBFinalizeNewIndex_function finalizeNewIndex;
 	ZDBUpdateMapping_function    updateMapping;

--- a/postgres/src/main/c/am/zdbam.c
+++ b/postgres/src/main/c/am/zdbam.c
@@ -194,6 +194,7 @@ static void xact_complete_cleanup(XactEvent event) {
 
         desc->implementation->transactionFinish(desc, event == XACT_EVENT_COMMIT ? ZDB_TRANSACTION_COMMITTED : ZDB_TRANSACTION_ABORTED);
     }
+	interface_transaction_cleanup();
 }
 
 static void zdbam_commit_xact_data()
@@ -1154,7 +1155,10 @@ zdbcostestimate(PG_FUNCTION_ARGS)
 				Const *queryConst = (Const *) queryNode;
 				if (query->len > 0)
 					appendStringInfo(query, " AND ");
-				appendStringInfo(query, "(%s)", TextDatumGetCString(queryConst->constvalue));
+				if (list_length(path->indexclauses) > 1)
+					appendStringInfo(query, "(%s)", TextDatumGetCString(queryConst->constvalue));
+				else
+					appendStringInfo(query, "%s", TextDatumGetCString(queryConst->constvalue));
 			}
 		}
 	}


### PR DESCRIPTION
improve performance when doing "joins" to other indexes by using an aggregate, along with using a terms filter, query caching, and one less round-trip to zdb_estimate_count() during query planning