### PR TITLE
report zombodb version

### DIFF
--- a/elasticsearch/src/main/resources/es-plugin.properties
+++ b/elasticsearch/src/main/resources/es-plugin.properties
@@ -1,1 +1,2 @@
 plugin=com.tcdi.zombodb.ZombodbPlugin
+version=${project.version}


### PR DESCRIPTION
Will adding a version key to the es-plugin.properties file have it properly report the installed version?

Example:
`http://localhost:9200/_cat/plugins`
Before:
```
nodename  marvel  1.3.1 j/s /_plugin/marvel/ 
nodename  Zombodb NA    j                    
```
After:
```
nodename  marvel  1.3.1 j/s /_plugin/marvel/ 
nodename  Zombodb x.y.z j
```