### PR TITLE
fixing issue #185. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ postgres/src/main/sql/zombodb--3.1.7.sql
 postgres/src/test/sql/setup.sql
 postgres/src/test/sql/so_comments.sql
 postgres/src/test/sql/TUTORIAL.sql
+postgres/src/test/zdbtaptests/tests/expand-same.sql
 postgres/results
 postgres/regression.*
 cmake-build-debug/

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/optimizers/ExpansionOptimizer.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/optimizers/ExpansionOptimizer.java
@@ -100,7 +100,10 @@ public class ExpansionOptimizer {
                     if (generatedExpansionsStack.isEmpty() && expansion.getIndexLink() == myIndex) {
                         last = expansion.getQuery();
                     } else {
-                        last = loadFielddata(expansion, expansion.getIndexLink().getLeftFieldname(), expansion.getIndexLink().getRightFieldname());
+                        if ("(null)".equals(expansion.getIndexLink().getLeftFieldname()))
+                            last = expansion.getQuery();
+                        else
+                            last = loadFielddata(expansion, expansion.getIndexLink().getLeftFieldname(), expansion.getIndexLink().getRightFieldname());
                     }
 
                     // replace the ASTExpansion in the tree with the fieldData version

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/optimizers/IndexLinkOptimizer.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/optimizers/IndexLinkOptimizer.java
@@ -184,7 +184,7 @@ public class IndexLinkOptimizer {
                     alias = lastExpansion.getIndexLink().getAlias();
                 }
 
-                if (leftFieldname.equals(rightFieldname))
+                if (leftFieldname.equals(rightFieldname) && next == null)
                     break;
 
                 ASTIndexLink newLink = ASTIndexLink.create(leftFieldname, indexName, alias, rightFieldname);

--- a/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/rewriters/SirenQueryRewriter.java
+++ b/elasticsearch/src/main/java/com/tcdi/zombodb/query_parser/rewriters/SirenQueryRewriter.java
@@ -47,9 +47,12 @@ public class SirenQueryRewriter extends QueryRewriter {
         ASTIndexLink myIndex = metadataManager.getMyIndex();
         FilterBuilder filter;
 
-        if (link.toString().equals(myIndex.toString()) && !node.isGenerated()) {
+        if (link == myIndex && !node.isGenerated()) {
             return super.build(node);
         } else {
+            if ("(null)".equals(link.getLeftFieldname()))
+                return super.build(node);
+
             if (_isBuildingAggregate)
                 return matchAllQuery();
 

--- a/postgres/Makefile
+++ b/postgres/Makefile
@@ -35,6 +35,7 @@ src/test/sql/TUTORIAL.sql:
 	gunzip -c src/test/sql/TUTORIAL.sql.gz > src/test/sql/TUTORIAL.sql
 
 pgtap:
+	src/test/zdbtaptests/tests/build-same.sh > src/test/zdbtaptests/tests/expand-same.sql
 	if [ "x" = "x${TEST}" ] ; then psql -qAt template1 -f src/test/zdbtaptests/sql/teardown.sql ; fi
 	if [ "x" = "x${TEST}" ] ; then psql -qAt template1 -f src/test/zdbtaptests/sql/setup.sql ; fi
 	if [ "x" = "x${TEST}" ] ; then pg_prove -d zdbtaptests src/test/zdbtaptests/tests/*.sql ; fi
@@ -61,7 +62,7 @@ DATA = $(wildcard src/main/sql/$(EXTENSION)--*--*.sql) src/main/sql/$(EXTENSION)
 ES_HOST ?= localhost
 
 # add the SQL for this version to clean target
-EXTRA_CLEAN += src/main/sql/$(EXTENSION)--$(EXTVERSION).sql src/test/sql/setup.sql src/test/sql/so_comments.sql src/test/sql/TUTORIAL.sql
+EXTRA_CLEAN += src/main/sql/$(EXTENSION)--$(EXTVERSION).sql src/test/sql/setup.sql src/test/sql/so_comments.sql src/test/sql/TUTORIAL.sql src/test/zdbtaptests/tests/expand-same.sql
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/postgres/src/test/zdbtaptests/sql/setup.sql
+++ b/postgres/src/test/zdbtaptests/sql/setup.sql
@@ -256,4 +256,127 @@ CREATE VIEW unit_tests.consolidated_record_view AS
 VACUUM ANALYZE unit_tests.data;
 VACUUM ANALYZE unit_tests.var;
 VACUUM ANALYZE unit_tests.vol;
+
+
+-- same as above, but with similarly-named primary key columns
+--**********************************************************************************************************************
+
+CREATE TABLE unit_tests.data_same AS SELECT * FROM unit_tests.data;
+CREATE TABLE unit_tests.var_same AS SELECT * FROM unit_tests.var;
+CREATE TABLE unit_tests.vol_same AS SELECT * FROM unit_tests.vol;
+
+ALTER TABLE unit_tests.data_same RENAME COLUMN pk_data TO id;
+ALTER TABLE unit_tests.var_same RENAME COLUMN pk_var TO id;
+ALTER TABLE unit_tests.vol_same RENAME COLUMN pk_vol TO id;
+
+
+CREATE INDEX es_unit_tests_data_same ON unit_tests.data_same USING zombodb (zdb('unit_tests.data_same', ctid), zdb(data_same.*)) WITH (url=:zombodb_url, options='id = <var_same.es_unit_tests_var_same>id, id = <vol_same.es_unit_tests_vol_same>id', shards='3', replicas='1');
+CREATE INDEX es_unit_tests_var_same ON unit_tests.var_same USING zombodb (zdb('unit_tests.var_same', ctid), zdb(var_same.*)) WITH (url=:zombodb_url, shards='3', replicas='1');
+CREATE INDEX es_unit_tests_vol_same ON unit_tests.vol_same USING zombodb (zdb('unit_tests.vol_same', ctid), zdb(vol_same.*)) WITH (url=:zombodb_url, shards='3', replicas='1');
+
+CREATE VIEW unit_tests.consolidated_record_view_same AS
+  SELECT data_same.id
+    , data_bigint_1
+    , data_bigint_expand_group
+    , data_bigint_array_1
+    , data_bigint_array_2
+    , data_boolean
+    , data_char_1
+    , data_char_2
+    , data_char_array_1
+    , data_char_array_2
+    , data_date_1
+    , data_date_2
+    , data_date_array_1
+    , data_date_array_2
+    , data_full_text
+    , data_full_text_shingles
+    , data_int_1
+    , data_int_2
+    , data_int_array_1
+    , data_int_array_2
+    , data_json
+    , data_phrase_1
+    , data_phrase_2
+    , data_phrase_array_1
+    , data_phrase_array_2
+    , data_text_1
+    , data_text_filter
+    , data_text_array_1
+    , data_text_array_2
+    , data_timestamp
+    , data_varchar_1
+    , data_varchar_2
+    , data_varchar_array_1
+    , data_varchar_array_2
+    , var_bigint_1
+    , var_bigint_expand_group
+    , var_bigint_array_1
+    , var_bigint_array_2
+    , var_boolean
+    , var_char_1
+    , var_char_2
+    , var_char_array_1
+    , var_char_array_2
+    , var_date_1
+    , var_date_2
+    , var_date_array_1
+    , var_date_array_2
+    , var_int_1
+    , var_int_2
+    , var_int_array_1
+    , var_int_array_2
+    , var_json
+    , var_phrase_1
+    , var_phrase_2
+    , var_phrase_array_1
+    , var_phrase_array_2
+    , var_text_1
+    , var_text_filter
+    , var_text_array_1
+    , var_text_array_2
+    , var_timestamp
+    , var_varchar_1
+    , var_varchar_2
+    , var_varchar_array_1
+    , var_varchar_array_2
+    , vol_bigint_1
+    , vol_bigint_expand_group
+    , vol_bigint_array_1
+    , vol_bigint_array_2
+    , vol_boolean
+    , vol_char_1
+    , vol_char_2
+    , vol_char_array_1
+    , vol_char_array_2
+    , vol_date_1
+    , vol_date_2
+    , vol_date_array_1
+    , vol_date_array_2
+    , vol_int_1
+    , vol_int_2
+    , vol_int_array_1
+    , vol_int_array_2
+    , vol_json
+    , vol_phrase_1
+    , vol_phrase_2
+    , vol_phrase_array_1
+    , vol_phrase_array_2
+    , vol_text_1
+    , vol_text_filter
+    , vol_text_array_1
+    , vol_text_array_2
+    , vol_timestamp
+    , vol_varchar_1
+    , vol_varchar_2
+    , vol_varchar_array_1
+    , vol_varchar_array_2
+    , zdb('unit_tests.data_same', data_same.ctid) AS zdb
+  FROM unit_tests.data_same
+  LEFT JOIN unit_tests.var_same ON data_same.id = var_same.id
+  LEFT JOIN unit_tests.vol_same ON data_same.id = vol_same.id;
+
+VACUUM ANALYZE unit_tests.data_same;
+VACUUM ANALYZE unit_tests.var_same;
+VACUUM ANALYZE unit_tests.vol_same;
 --**********************************************************************************************************************

--- a/postgres/src/test/zdbtaptests/sql/setup.sql
+++ b/postgres/src/test/zdbtaptests/sql/setup.sql
@@ -269,6 +269,9 @@ ALTER TABLE unit_tests.data_same RENAME COLUMN pk_data TO id;
 ALTER TABLE unit_tests.var_same RENAME COLUMN pk_var TO id;
 ALTER TABLE unit_tests.vol_same RENAME COLUMN pk_vol TO id;
 
+ALTER TABLE unit_tests.data_same ADD PRIMARY KEY (id);
+ALTER TABLE unit_tests.var_same ADD PRIMARY KEY (id);
+ALTER TABLE unit_tests.vol_same ADD PRIMARY KEY (id);
 
 CREATE INDEX es_unit_tests_data_same ON unit_tests.data_same USING zombodb (zdb('unit_tests.data_same', ctid), zdb(data_same.*)) WITH (url=:zombodb_url, options='id = <var_same.es_unit_tests_var_same>id, id = <vol_same.es_unit_tests_vol_same>id', shards='3', replicas='1');
 CREATE INDEX es_unit_tests_var_same ON unit_tests.var_same USING zombodb (zdb('unit_tests.var_same', ctid), zdb(var_same.*)) WITH (url=:zombodb_url, shards='3', replicas='1');

--- a/postgres/src/test/zdbtaptests/tests/build-same.sh
+++ b/postgres/src/test/zdbtaptests/tests/build-same.sh
@@ -1,0 +1,33 @@
+#
+# This copies "expand.sql" and builds a new version against the view called "consolidated_record_view_same"
+# to assert that all the queries in expand.sql return the same results against a view (with a set of index links)
+# where the key columns have the same name -- in this case "id"
+#
+# This is a re-create for issue #185 (https://github.com/zombodb/zombodb/issues/185) that hopefully will automatically
+# pickup potential bugs that are added as test cases in expand.sql
+#
+# This script is called automatically by "make installcheck" and "make pgtap" -- there is no need to call it manually
+#
+#! /bin/sh
+
+SOURCE_FILE=src/test/zdbtaptests/tests/expand.sql
+
+echo "BEGIN;"
+grep "SELECT plan" $SOURCE_FILE
+
+IFS="
+"
+x=1 
+for f in `grep "PREPARE zdb_result" $SOURCE_FILE` ; do 
+	echo "DEALLOCATE ALL;"
+	echo $f | sed 's/zdb_result/expected_result/'
+	echo $f | sed 's/pk_data/id/' | sed 's/consolidated_record_view/consolidated_record_view_same/' | sed 's/zdb_result/zdb_result     /'
+	echo "SELECT set_eq('expected_result', 'zdb_result', '$x');"
+	x=$((x+1))
+	echo "--***"
+	echo
+done
+
+echo "SELECT * FROM finish();"
+echo "ROLLBACK;"
+


### PR DESCRIPTION
This fixes issue #185 and adds an auto-generated (during `make installcheck` or `make pgtap`) tap test called `expand-same.sql`.  

The generated test uses all the source ZDB queries from `expand.sql` and compares them to the new view (and its corresponding tables) to ensure the results are the same.