### PR TITLE
fixing issue #257

### DIFF
--- a/elasticsearch/src/main/java/llc/zombodb/cross_join/CrossJoinQueryRewriteHelper.java
+++ b/elasticsearch/src/main/java/llc/zombodb/cross_join/CrossJoinQueryRewriteHelper.java
@@ -106,8 +106,7 @@ class CrossJoinQueryRewriteHelper {
     }
 
 
-    static Query rewriteQuery(CrossJoinQuery crossJoin) {
-        FastTermsResponse fastTerms = crossJoin.getFastTerms();
+    static Query rewriteQuery(CrossJoinQuery crossJoin, FastTermsResponse fastTerms) {
 
         if (fastTerms.getTotalDataCount() == 0)
             return new MatchNoDocsQuery();


### PR DESCRIPTION
1) Detect non-started shards in TransportFastTermsAction
2) Better handle shard errors and no-responses in TransportFastTermsAction
3) Don't override .rewrite() in CrossJoinQuery, instead do the rewrite in
.createWeight() so that we run the FastTermsAction after ES has had an
opportunity to cache our query
4) Remove the internal caching ZDB was doing in CrossJoinQuery as it's not
actually necessary
5) Teach ZomboDBCountAction to detect shard failures and return an error
instead