### PR TITLE
Rewrite max_terms=0 to Integer.MAX_VALUE for tally aggregation

### DIFF
--- a/elasticsearch/src/main/java/llc/zombodb/query_parser/rewriters/QueryRewriter.java
+++ b/elasticsearch/src/main/java/llc/zombodb/query_parser/rewriters/QueryRewriter.java
@@ -418,7 +418,7 @@ public abstract class QueryRewriter {
         } else {
             TermsAggregationBuilder tb = terms(agg.getFieldname())
                     .field(fieldname)
-                    .size(agg.getMaxTerms())
+                    .size(agg.getMaxTerms() == 0 ? Integer.MAX_VALUE : agg.getMaxTerms())
                     .shardSize(agg.getShardSize() == 0 ? Integer.MAX_VALUE : agg.getShardSize())
                     .order(stringToTermsOrder(agg.getSortOrder()));
 

--- a/elasticsearch/src/test/java/llc/zombodb/query_parser/TestQueryRewriter.java
+++ b/elasticsearch/src/test/java/llc/zombodb/query_parser/TestQueryRewriter.java
@@ -5028,6 +5028,17 @@ public class TestQueryRewriter extends ZomboDBTestCase {
     }
 
     @Test
+    public void testMaxTermsZeroExpandsToIntegerMaxValue() throws Exception {
+        QueryRewriter qr;
+
+        qr = qr("#tally(field, \"^.*\", 0, \"term\", 50)");
+        assertEquals(
+                "\"field\"{\"terms\":{\"field\":\"field\",\"size\":" + Integer.MAX_VALUE + ",\"shard_size\":50,\"min_doc_count\":1,\"shard_min_doc_count\":0,\"show_term_doc_count_error\":false,\"order\":{\"_term\":\"asc\"}}}",
+                qr.rewriteAggregations().toXContent(JsonXContent.contentBuilder(), null).string()
+        );
+    }
+
+    @Test
     public void testIssue132() throws Exception {
         assertAST("#expand<group_id=<this.index>group_id>(#expand<group_id=<this.index>group_id>(pk_id:3 OR pk_id:5))",
                 "QueryTree\n" +


### PR DESCRIPTION
Quick fix for the max_terms=0 so the behavior matches the docs