### PR TITLE
Resolve Issue 273

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.swp
 .DS_store
 foo.*
-src/sql/zombodb--10-1.0.0b4.sql
+src/sql/zombodb--10-1.0.0b5.sql
 results/
 regression.*
 cmake-build-debug/

--- a/CONFIGURATION-SETTINGS.md
+++ b/CONFIGURATION-SETTINGS.md
@@ -36,21 +36,6 @@ Defines the number of replicas all new indices should have.  Changing this value
 The below settings may be set in `postgresql.conf`, but they can also be changed per session/transaction using Postgres `SET key TO value` command;
 
 
-
-```
-zdb.batch_mode
-
-Type: boolean
-Default: false
-```
-
-When sychronizing changes from COPY/INSERT/UPDATE/DELETE statements to Elasticsearch, ZomboDB does so at the end of each *statement*.  For long-running transactions that modify lots of individual rows, it may make sense to turn `zdb.batch_mode` to on.  This indicates that ZDB should batch Elasticsearch index synchronization changes until the transaction `COMMIT`s.  This can significantly improve performance in these kinds of situations.
-
-Note that if `zdb.batch_mode` is on, ZomboDB queries won't see the index changes until after the controlling transaction commits.
-
-
-
-
 ```
 zdb.default_row_estimate
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,6 @@ This is a new version of ZomboDB that only supports Postgres 10 and doesn't requ
 
 If you've used ZomboDB before, you'll learn that this is a different and more advanced product. Please review all the documentation as many things (including SQL syntax and query language) have changed.
 
-Since this is beta software, there's a short TODO-list:
-
-- Support Postgres sub-transactions (`SAVEPOINT` and `ROLLBACK TO SAVEPOINT`)
-- Eliminate the `zdb.batch_mode` setting by automatically batching index modifications and writing to Elasticsearch prior to an index query while in an open transaction or at transaction commit.
-
 Previous versions that support Postgres <=9.5 are still available, from these branches:
 
 - [Support for Elasticsearch 5.6](https://github.com/zombodb/zombodb/tree/master-es5.6)

--- a/THINGS-TO-KNOW.md
+++ b/THINGS-TO-KNOW.md
@@ -6,7 +6,7 @@ Postgres<-->Elasticsearch integrations are usually implemented in application co
 
 ZomboDB ties into Postgres' Index Access Method API, which means it's synchronous.  This is not to say that ZomboDB isn't also concurrent -- it most definitely is.  However, any COPY/INSERT/UPDATE/DELETE in a given Postgres session against a table with a ZomboDB index will round-trip to Elasticsearch.
 
-ZomboDB does, however, batch Elasticsearch indexing requests by statement (**not** by row).  It can also batch by transaction if `zdb.batch_mode` is on.  This reduces the number of round trips to Elasticsearch to the minimal amount.
+ZomboDB does, however, batch Elasticsearch indexing requests by transaction (**not** by row).  This approach reduces the number of round trips to Elasticsearch to the minimal amount.  If during a transaction, a batch needs to be sent to Elasticsearch in order to properly a search (a SELECT or aggregate function) then ZomboDB will do that automatically.
 
 Because ZomboDB is an index type, it (along with help from Postgres) guarantees MVCC correctness across all queries that use it.  This includes normal WHERE clause conditions along with SQL-functions that perform Elasticsearch-specifc aggregates that are wholly solved within the Elasticsearch cluster.
 

--- a/src/c/indexam/zdbam.c
+++ b/src/c/indexam/zdbam.c
@@ -162,7 +162,7 @@ void finish_inserts(bool is_commit) {
 		ListCell *lc2;
 
 		foreach(lc2, aborted_xids) {
-			list_delete_int(context->esContext->usedXids, lfirst_int(lc2));
+			(void) list_delete_int(context->esContext->usedXids, lfirst_int(lc2));
 		}
 
 		ElasticsearchFinishBulkProcess(context->esContext, is_commit);
@@ -192,6 +192,7 @@ ArrayType *collect_used_xids(MemoryContext memoryContext) {
 	return DatumGetArrayTypeP(makeArrayResult(astate, memoryContext));
 }
 
+/*lint -esym 715,mySubid,parentSubid,arg ignore unused param */
 static void subxact_callback(SubXactEvent event, SubTransactionId mySubid, SubTransactionId parentSubid, void *arg) {
 	switch (event) {
 		case SUBXACT_EVENT_ABORT_SUB: {
@@ -201,7 +202,7 @@ static void subxact_callback(SubXactEvent event, SubTransactionId mySubid, SubTr
 				MemoryContext oldContext;
 
 				oldContext = MemoryContextSwitchTo(TopTransactionContext);
-				aborted_xids = lappend_int(aborted_xids, curr_xid);
+				aborted_xids = lappend_int(aborted_xids, (int) curr_xid);
 				MemoryContextSwitchTo(oldContext);
 			}
 		} break;

--- a/src/c/indexam/zdbam.h
+++ b/src/c/indexam/zdbam.h
@@ -31,5 +31,6 @@ typedef struct ZDBIndexChangeContext {
 
 ZDBIndexChangeContext *checkout_insert_context(Relation indexRelation, Datum row, bool isnull);
 void finish_inserts(bool is_commit);
+ArrayType *collect_used_xids(MemoryContext context);
 
 #endif /* __ZDB_ZDBAM_H__ */

--- a/src/c/indexam/zdbam.h
+++ b/src/c/indexam/zdbam.h
@@ -30,5 +30,6 @@ typedef struct ZDBIndexChangeContext {
 
 
 ZDBIndexChangeContext *checkout_insert_context(Relation indexRelation, Datum row, bool isnull);
+void finish_inserts(bool is_commit);
 
 #endif /* __ZDB_ZDBAM_H__ */

--- a/src/c/json/json.c
+++ b/src/c/json/json.c
@@ -30,8 +30,6 @@
 
 #include "postgres.h"
 #include "mb/pg_wchar.h"
-#include "lib/stringinfo.h"
-#include <stdlib.h>
 
 // work around MSVC 2013 and lower not having strtoull
 #if defined(_MSC_VER) && (_MSC_VER <= 1800)

--- a/src/c/json/json.h
+++ b/src/c/json/json.h
@@ -36,7 +36,7 @@
 #pragma warning(disable : 4820)
 #endif
 
-#include <stddef.h>
+#include "postgres.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -121,7 +121,7 @@ enum json_parse_flags_e {
 // Parse a JSON text file, returning a pointer to the root of the JSON
 // structure. json_parse performs 1 call to malloc for the entire encoding.
 // Returns 0 if an error occurred (malformed JSON input, or malloc failed)
-struct json_value_s *json_parse(const void *src, size_t src_size);
+//struct json_value_s *json_parse(const void *src, size_t src_size);
 
 // Parse a JSON text file, returning a pointer to the root of the JSON
 // structure. json_parse performs 1 call to malloc for the entire encoding.
@@ -139,7 +139,7 @@ struct json_value_s *json_parse_ex(const void *src, size_t src_size,
 // json_write_minified performs 1 call to malloc for the entire encoding.
 // Return 0 if an error occurred (malformed JSON input, or malloc failed).
 // The out_size parameter is optional as the utf-8 string is null terminated.
-void *json_write_minified(const struct json_value_s *value, size_t *out_size);
+//void *json_write_minified(const struct json_value_s *value, size_t *out_size);
 
 // Write out a pretty JSON utf-8 string. This string is encoded such that the
 // resultant JSON is pretty in that it is easily human readable. The indent and
@@ -150,8 +150,8 @@ void *json_write_minified(const struct json_value_s *value, size_t *out_size);
 // json_write_pretty performs 1 call to malloc for the entire encoding.
 // Return 0 if an error occurred (malformed JSON input, or malloc failed).
 // The out_size parameter is optional as the utf-8 string is null terminated.
-void *json_write_pretty(const struct json_value_s *value, const char *indent,
-						const char *newline, size_t *out_size);
+//void *json_write_pretty(const struct json_value_s *value, const char *indent,
+//						const char *newline, size_t *out_size);
 
 // The various types JSON values can be. Used to identify what a value is
 enum json_type_e {

--- a/src/c/utils/utils.h
+++ b/src/c/utils/utils.h
@@ -29,8 +29,6 @@
 #define ItemPointerToUint64(ht_ctid) ((((uint64)(ItemPointerGetBlockNumber(ht_ctid))) << 32) | ((uint32)(ItemPointerGetOffsetNumber(ht_ctid))))
 #define GET_STR(textp) DatumGetCString(DirectFunctionCall1(textout, PointerGetDatum(textp)))
 
-#define IsBatchMode() (zdb_batch_mode_guc || IsTransactionBlock() == false)
-
 void freeStringInfo(StringInfo si);
 Oid get_base_type_oid(Oid typeOid);
 TupleDesc lookup_composite_tupdesc(Datum composite);

--- a/src/c/zombodb.h
+++ b/src/c/zombodb.h
@@ -32,6 +32,6 @@
 #include "utils/utils.h"
 #include <assert.h>
 
-#define ZDB_VERSION "10-1.0.0b4"
+#define ZDB_VERSION "10-1.0.0b5"
 
 #endif /* __ZDB_ZDB__H__ */

--- a/src/flint/gcc-include-path.lnt
+++ b/src/flint/gcc-include-path.lnt
@@ -1,5 +1,5 @@
 --i"/usr/local/include"
 --i"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"
---i"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/9.1.0/include"
+--i"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/10.0.0/include"
 --i"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include"
---i"/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/usr/include"
+--i"/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/include"

--- a/src/flint/lint_cmac.h
+++ b/src/flint/lint_cmac.h
@@ -41,8 +41,22 @@
 #define __DBL_MIN__ 2.2250738585072014e-308
 #define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
 #define __DYNAMIC__ 1
-#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101300
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101400
 #define __FINITE_MATH_ONLY__ 0
+#define __FLT16_DECIMAL_DIG__ 5
+#define __FLT16_DENORM_MIN__ 5.9604644775390625e-8F16
+#define __FLT16_DIG__ 3
+#define __FLT16_EPSILON__ 9.765625e-4F16
+#define __FLT16_HAS_DENORM__ 1
+#define __FLT16_HAS_INFINITY__ 1
+#define __FLT16_HAS_QUIET_NAN__ 1
+#define __FLT16_MANT_DIG__ 11
+#define __FLT16_MAX_10_EXP__ 4
+#define __FLT16_MAX_EXP__ 15
+#define __FLT16_MAX__ 6.5504e+4F16
+#define __FLT16_MIN_10_EXP__ (-13)
+#define __FLT16_MIN_EXP__ (-14)
+#define __FLT16_MIN__ 6.103515625e-5F16
 #define __FLT_DECIMAL_DIG__ 9
 #define __FLT_DENORM_MIN__ 1.40129846e-45F
 #define __FLT_DIG__ 6
@@ -81,12 +95,12 @@
 #define __GNUC_STDC_INLINE__ 1
 #define __GNUC__ 4
 #define __GXX_ABI_VERSION 1002
-#define __INT16_C_SUFFIX__
+#define __INT16_C_SUFFIX__ 
 #define __INT16_FMTd__ "hd"
 #define __INT16_FMTi__ "hi"
 #define __INT16_MAX__ 32767
 #define __INT16_TYPE__ short
-#define __INT32_C_SUFFIX__
+#define __INT32_C_SUFFIX__ 
 #define __INT32_FMTd__ "d"
 #define __INT32_FMTi__ "i"
 #define __INT32_MAX__ 2147483647
@@ -96,7 +110,7 @@
 #define __INT64_FMTi__ "lli"
 #define __INT64_MAX__ 9223372036854775807LL
 #define __INT64_TYPE__ long long int
-#define __INT8_C_SUFFIX__
+#define __INT8_C_SUFFIX__ 
 #define __INT8_FMTd__ "hhd"
 #define __INT8_FMTi__ "hhi"
 #define __INT8_MAX__ 127
@@ -168,6 +182,11 @@
 #define __NO_INLINE__ 1
 #define __NO_MATH_INLINES 1
 #define __OBJC_BOOL_IS_BOOL 0
+#define __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES 3
+#define __OPENCL_MEMORY_SCOPE_DEVICE 2
+#define __OPENCL_MEMORY_SCOPE_SUB_GROUP 4
+#define __OPENCL_MEMORY_SCOPE_WORK_GROUP 1
+#define __OPENCL_MEMORY_SCOPE_WORK_ITEM 0
 #define __ORDER_BIG_ENDIAN__ 4321
 #define __ORDER_LITTLE_ENDIAN__ 1234
 #define __ORDER_PDP_ENDIAN__ 3412
@@ -179,7 +198,7 @@
 #define __PTRDIFF_MAX__ 9223372036854775807L
 #define __PTRDIFF_TYPE__ long int
 #define __PTRDIFF_WIDTH__ 64
-#define __REGISTER_PREFIX__
+#define __REGISTER_PREFIX__ 
 #define __SCHAR_MAX__ 127
 #define __SHRT_MAX__ 32767
 #define __SIG_ATOMIC_MAX__ 2147483647
@@ -218,7 +237,7 @@
 #define __STDC_UTF_32__ 1
 #define __STDC_VERSION__ 201112L
 #define __STDC__ 1
-#define __UINT16_C_SUFFIX__
+#define __UINT16_C_SUFFIX__ 
 #define __UINT16_FMTX__ "hX"
 #define __UINT16_FMTo__ "ho"
 #define __UINT16_FMTu__ "hu"
@@ -239,7 +258,7 @@
 #define __UINT64_FMTx__ "llx"
 #define __UINT64_MAX__ 18446744073709551615ULL
 #define __UINT64_TYPE__ long long unsigned int
-#define __UINT8_C_SUFFIX__
+#define __UINT8_C_SUFFIX__ 
 #define __UINT8_FMTX__ "hhX"
 #define __UINT8_FMTo__ "hho"
 #define __UINT8_FMTu__ "hhu"
@@ -310,21 +329,22 @@
 #define __UINT_LEAST8_MAX__ 255
 #define __UINT_LEAST8_TYPE__ unsigned char
 #define __USER_LABEL_PREFIX__ _
-#define __VERSION__ "4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)"
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)"
 #define __WCHAR_MAX__ 2147483647
 #define __WCHAR_TYPE__ int
 #define __WCHAR_WIDTH__ 32
+#define __WINT_MAX__ 2147483647
 #define __WINT_TYPE__ int
 #define __WINT_WIDTH__ 32
 #define __amd64 1
 #define __amd64__ 1
-#define __apple_build_version__ 9020039
+#define __apple_build_version__ 10001145
 #define __block __attribute__((__blocks__(byref)))
 #define __clang__ 1
-#define __clang_major__ 9
-#define __clang_minor__ 1
+#define __clang_major__ 10
+#define __clang_minor__ 0
 #define __clang_patchlevel__ 0
-#define __clang_version__ "9.1.0 (clang-902.0.39.2)"
+#define __clang_version__ "10.0.0 (clang-1000.11.45.2)"
 #define __core2 1
 #define __core2__ 1
 #define __llvm__ 1
@@ -332,9 +352,9 @@
 #define __null_unspecified _Null_unspecified
 #define __nullable _Nullable
 #define __pic__ 2
-#define __strong
+#define __strong 
 #define __tune_core2__ 1
-#define __unsafe_unretained
+#define __unsafe_unretained 
 #define __weak __attribute__((objc_gc(weak)))
 #define __x86_64 1
 #define __x86_64__ 1

--- a/src/flint/lint_cppmac.h
+++ b/src/flint/lint_cppmac.h
@@ -42,9 +42,23 @@
 #define __DECIMAL_DIG__ __LDBL_DECIMAL_DIG__
 #define __DEPRECATED 1
 #define __DYNAMIC__ 1
-#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101300
+#define __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ 101400
 #define __EXCEPTIONS 1
 #define __FINITE_MATH_ONLY__ 0
+#define __FLT16_DECIMAL_DIG__ 5
+#define __FLT16_DENORM_MIN__ 5.9604644775390625e-8F16
+#define __FLT16_DIG__ 3
+#define __FLT16_EPSILON__ 9.765625e-4F16
+#define __FLT16_HAS_DENORM__ 1
+#define __FLT16_HAS_INFINITY__ 1
+#define __FLT16_HAS_QUIET_NAN__ 1
+#define __FLT16_MANT_DIG__ 11
+#define __FLT16_MAX_10_EXP__ 4
+#define __FLT16_MAX_EXP__ 15
+#define __FLT16_MAX__ 6.5504e+4F16
+#define __FLT16_MIN_10_EXP__ (-13)
+#define __FLT16_MIN_EXP__ (-14)
+#define __FLT16_MIN__ 6.103515625e-5F16
 #define __FLT_DECIMAL_DIG__ 9
 #define __FLT_DENORM_MIN__ 1.40129846e-45F
 #define __FLT_DIG__ 6
@@ -88,12 +102,12 @@
 #define __GXX_ABI_VERSION 1002
 #define __GXX_RTTI 1
 #define __GXX_WEAK__ 1
-#define __INT16_C_SUFFIX__
+#define __INT16_C_SUFFIX__ 
 #define __INT16_FMTd__ "hd"
 #define __INT16_FMTi__ "hi"
 #define __INT16_MAX__ 32767
 #define __INT16_TYPE__ short
-#define __INT32_C_SUFFIX__
+#define __INT32_C_SUFFIX__ 
 #define __INT32_FMTd__ "d"
 #define __INT32_FMTi__ "i"
 #define __INT32_MAX__ 2147483647
@@ -103,7 +117,7 @@
 #define __INT64_FMTi__ "lli"
 #define __INT64_MAX__ 9223372036854775807LL
 #define __INT64_TYPE__ long long int
-#define __INT8_C_SUFFIX__
+#define __INT8_C_SUFFIX__ 
 #define __INT8_FMTd__ "hhd"
 #define __INT8_FMTi__ "hhi"
 #define __INT8_MAX__ 127
@@ -175,6 +189,11 @@
 #define __NO_INLINE__ 1
 #define __NO_MATH_INLINES 1
 #define __OBJC_BOOL_IS_BOOL 0
+#define __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES 3
+#define __OPENCL_MEMORY_SCOPE_DEVICE 2
+#define __OPENCL_MEMORY_SCOPE_SUB_GROUP 4
+#define __OPENCL_MEMORY_SCOPE_WORK_GROUP 1
+#define __OPENCL_MEMORY_SCOPE_WORK_ITEM 0
 #define __ORDER_BIG_ENDIAN__ 4321
 #define __ORDER_LITTLE_ENDIAN__ 1234
 #define __ORDER_PDP_ENDIAN__ 3412
@@ -186,7 +205,7 @@
 #define __PTRDIFF_MAX__ 9223372036854775807L
 #define __PTRDIFF_TYPE__ long int
 #define __PTRDIFF_WIDTH__ 64
-#define __REGISTER_PREFIX__
+#define __REGISTER_PREFIX__ 
 #define __SCHAR_MAX__ 127
 #define __SHRT_MAX__ 32767
 #define __SIG_ATOMIC_MAX__ 2147483647
@@ -225,7 +244,7 @@
 #define __STDC_UTF_16__ 1
 #define __STDC_UTF_32__ 1
 #define __STDC__ 1
-#define __UINT16_C_SUFFIX__
+#define __UINT16_C_SUFFIX__ 
 #define __UINT16_FMTX__ "hX"
 #define __UINT16_FMTo__ "ho"
 #define __UINT16_FMTu__ "hu"
@@ -246,7 +265,7 @@
 #define __UINT64_FMTx__ "llx"
 #define __UINT64_MAX__ 18446744073709551615ULL
 #define __UINT64_TYPE__ long long unsigned int
-#define __UINT8_C_SUFFIX__
+#define __UINT8_C_SUFFIX__ 
 #define __UINT8_FMTX__ "hhX"
 #define __UINT8_FMTo__ "hho"
 #define __UINT8_FMTu__ "hhu"
@@ -317,21 +336,22 @@
 #define __UINT_LEAST8_MAX__ 255
 #define __UINT_LEAST8_TYPE__ unsigned char
 #define __USER_LABEL_PREFIX__ _
-#define __VERSION__ "4.2.1 Compatible Apple LLVM 9.1.0 (clang-902.0.39.2)"
+#define __VERSION__ "4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.11.45.2)"
 #define __WCHAR_MAX__ 2147483647
 #define __WCHAR_TYPE__ int
 #define __WCHAR_WIDTH__ 32
+#define __WINT_MAX__ 2147483647
 #define __WINT_TYPE__ int
 #define __WINT_WIDTH__ 32
 #define __amd64 1
 #define __amd64__ 1
-#define __apple_build_version__ 9020039
+#define __apple_build_version__ 10001145
 #define __block __attribute__((__blocks__(byref)))
 #define __clang__ 1
-#define __clang_major__ 9
-#define __clang_minor__ 1
+#define __clang_major__ 10
+#define __clang_minor__ 0
 #define __clang_patchlevel__ 0
-#define __clang_version__ "9.1.0 (clang-902.0.39.2)"
+#define __clang_version__ "10.0.0 (clang-1000.11.45.2)"
 #define __core2 1
 #define __core2__ 1
 #define __cplusplus 199711L
@@ -344,9 +364,9 @@
 #define __nullable _Nullable
 #define __pic__ 2
 #define __private_extern__ extern
-#define __strong
+#define __strong 
 #define __tune_core2__ 1
-#define __unsafe_unretained
+#define __unsafe_unretained 
 #define __weak __attribute__((objc_gc(weak)))
 #define __x86_64 1
 #define __x86_64__ 1

--- a/src/sql/zombodb--10-1.0.0b4--10-1.0.0b5.sql
+++ b/src/sql/zombodb--10-1.0.0b4--10-1.0.0b5.sql
@@ -1,0 +1,1 @@
+-- no sql changes

--- a/src/sql/zombodb--10-1.0.0b4--10-1.0.0b5.sql
+++ b/src/sql/zombodb--10-1.0.0b4--10-1.0.0b5.sql
@@ -1,1 +1,76 @@
--- no sql changes
+DROP FUNCTION zdb.visibility_clause(myXid bigint, myXmax bigint, myCid int, active_xids bigint[], index regclass, type text);
+CREATE OR REPLACE FUNCTION zdb.visibility_clause(myXid bigint[], myXmax bigint, myCid int, active_xids bigint[], index regclass, type text) RETURNS zdbquery PARALLEL SAFE STABLE STRICT LANGUAGE sql AS $$
+/*
+* ((Xmin == my-transaction &&				inserted by the current transaction
+*	 Cmin < my-command &&					before this command, and
+*	 (Xmax is null ||						the row has not been deleted, or
+*	  (Xmax == my-transaction &&			it was deleted by the current transaction
+*	   Cmax >= my-command)))				but not before this command,
+* ||										or
+*	(Xmin is committed &&					the row was inserted by a committed transaction, and
+*		(Xmax is null ||					the row has not been deleted, or
+*		 (Xmax == my-transaction &&			the row is being deleted by this transaction
+*		  Cmax >= my-command) ||			but it's not deleted "yet", or
+*		 (Xmax != my-transaction &&			the row was deleted by another transaction
+*		  Xmax is not committed))))			that has not been committed
+*/
+
+/*
+    (
+        (xmin = "myXid"
+             AND cmin < "myCid"
+             AND (xmax = NULL OR (xmax = "myXid" AND cmax >= "myCid"))
+        )
+    OR
+        (
+            (NOT ({"terms":{"xmin":{"index":"$INDEX","path":"aborted_xids","type":"$TYPE","id":"aborted_xids"}}}) AND NOT xmin = [active_xids] AND NOT xmin >= "myXmax")
+        AND (xmax = NULL
+              OR (xmax = "myXid" AND cmax >= "myCid")
+              OR (xmax != "myXid"
+                    AND (({"terms":{"xmax":{"index":"$INDEX","path":"aborted_xids","type":"$TYPE","id":"aborted_xids"}}}) OR xmax = [active_xids] OR xmax >= "myXmax")
+                 )
+            )
+        )
+    )
+*/
+
+  SELECT dsl.must(
+      dsl.noteq('_id:zdb_aborted_xids'),
+      dsl.should(
+          dsl.must(
+              dsl.terms('zdb_xmin', VARIADIC myXid),
+              dsl.range(field => 'zdb_cmin', lt => myCid),
+              dsl.should(
+                  dsl.field_missing('zdb_xmax'),
+                  dsl.must(
+                      dsl.terms('zdb_xmax', VARIADIC myXid),
+                      dsl.range(field => 'zdb_cmax', gte => myCid)
+                  )
+              )
+          ),
+          dsl.must(
+              dsl.must(
+                  dsl.noteq(dsl.terms_lookup('zdb_xmin', zdb.index_name(index), type, 'zdb_aborted_xids', 'zdb_aborted_xids')),
+                  dsl.noteq(dsl.terms('zdb_xmin', VARIADIC active_xids)),
+                  dsl.noteq(dsl.range(field => 'zdb_xmin', gte => myXmax)),
+                  dsl.should(
+                      dsl.field_missing('zdb_xmax'),
+                      dsl.must(
+                          dsl.terms('zdb_xmax', VARIADIC myXid),
+                          dsl.range(field => 'zdb_cmax', gte => myCid)
+                      ),
+                      dsl.must(
+                          dsl.noteq(dsl.terms('zdb_xmax', VARIADIC myXid)),
+                          dsl.should(
+                              dsl.terms_lookup('zdb_xmax', zdb.index_name(index), type, 'zdb_aborted_xids', 'zdb_aborted_xids'),
+                              dsl.terms('zdb_xmax', VARIADIC active_xids),
+                              dsl.range(field => 'zdb_xmax', gte => myXmax)
+                          )
+                      )
+                  )
+              )
+          )
+      )
+  );
+$$;
+

--- a/src/test/expected/issue-273.out
+++ b/src/test/expected/issue-273.out
@@ -14,5 +14,40 @@ select txid_current() is not null;  -- burn current xid
 savepoint foo;
 update issue273 set id = id where id = 1;  -- gets next xid value
 commit; -- results in ERROR because "next xid value" doesn't exist in events' list of aborted xids.
-ERROR:  unexpected http response code from remote server.  code=400, response={"error":{"root_cause":[{"type":"remote_transport_exception","reason":"[OxNDdMz][127.0.0.1:9300][indices:data/write/update[s]]"}],"type":"illegal_argument_exception","reason":"failed to execute script","caused_by":{"type":"script_exception","reason":"runtime error","script_stack":[],"script":"ctx._source.zdb_aborted_xids.remove(ctx._source.zdb_aborted_xids.indexOf(params.XID));","lang":"painless","caused_by":{"type":"array_index_out_of_bounds_exception","reason":null}}},"status":400}
+begin;
+insert into issue273(id) values (2);
+savepoint three;
+insert into issue273(id) values (3);
+rollback to three;
+insert into issue273(id) values (4);
+commit;
+select * from issue273 order by id;
+ id |      data      
+----+----------------
+  1 | this is a test
+  2 | 
+  4 | 
+(3 rows)
+
+select * from zdb.terms('idxissue273', 'id', dsl.match_all(), 1000, 'term');
+ term | doc_count 
+------+-----------
+ 1    |         1
+ 2    |         1
+ 4    |         1
+(3 rows)
+
+SELECT jsonb_array_length((zdb.request('idxissue273', 'doc/zdb_aborted_xids?pretty')::jsonb)->'_source'->'zdb_aborted_xids');
+ jsonb_array_length 
+--------------------
+                  1
+(1 row)
+
+VACUUM issue273;
+SELECT jsonb_array_length((zdb.request('idxissue273', 'doc/zdb_aborted_xids?pretty')::jsonb)->'_source'->'zdb_aborted_xids');
+ jsonb_array_length 
+--------------------
+                  0
+(1 row)
+
 DROP TABLE issue273;

--- a/src/test/expected/issue-273.out
+++ b/src/test/expected/issue-273.out
@@ -16,10 +16,56 @@ update issue273 set id = id where id = 1;  -- gets next xid value
 commit; -- results in ERROR because "next xid value" doesn't exist in events' list of aborted xids.
 begin;
 insert into issue273(id) values (2);
+select * from issue273 order by id;
+ id |      data      
+----+----------------
+  1 | this is a test
+  2 | 
+(2 rows)
+
+select * from zdb.terms('idxissue273', 'id', dsl.match_all(), 1000, 'term');
+ term | doc_count 
+------+-----------
+ 1    |         1
+ 2    |         1
+(2 rows)
+
 savepoint three;
 insert into issue273(id) values (3);
+select * from issue273 order by id;
+ id |      data      
+----+----------------
+  1 | this is a test
+  2 | 
+  3 | 
+(3 rows)
+
+select * from zdb.terms('idxissue273', 'id', dsl.match_all(), 1000, 'term');
+ term | doc_count 
+------+-----------
+ 1    |         1
+ 2    |         1
+ 3    |         1
+(3 rows)
+
 rollback to three;
 insert into issue273(id) values (4);
+select * from issue273 order by id;
+ id |      data      
+----+----------------
+  1 | this is a test
+  2 | 
+  4 | 
+(3 rows)
+
+select * from zdb.terms('idxissue273', 'id', dsl.match_all(), 1000, 'term');
+ term | doc_count 
+------+-----------
+ 1    |         1
+ 2    |         1
+ 4    |         1
+(3 rows)
+
 commit;
 select * from issue273 order by id;
  id |      data      

--- a/src/test/expected/issue-273.out
+++ b/src/test/expected/issue-273.out
@@ -1,0 +1,18 @@
+CREATE TABLE issue273 (
+    id bigint not null primary key,
+    data text
+);
+insert into issue273 (id, data) values (1, 'this is a test');
+create index idxissue273 on issue273 using zombodb ((issue273.*));
+begin;
+select txid_current() is not null;  -- burn current xid
+ ?column? 
+----------
+ t
+(1 row)
+
+savepoint foo;
+update issue273 set id = id where id = 1;  -- gets next xid value
+commit; -- results in ERROR because "next xid value" doesn't exist in events' list of aborted xids.
+ERROR:  unexpected http response code from remote server.  code=400, response={"error":{"root_cause":[{"type":"remote_transport_exception","reason":"[OxNDdMz][127.0.0.1:9300][indices:data/write/update[s]]"}],"type":"illegal_argument_exception","reason":"failed to execute script","caused_by":{"type":"script_exception","reason":"runtime error","script_stack":[],"script":"ctx._source.zdb_aborted_xids.remove(ctx._source.zdb_aborted_xids.indexOf(params.XID));","lang":"painless","caused_by":{"type":"array_index_out_of_bounds_exception","reason":null}}},"status":400}
+DROP TABLE issue273;

--- a/src/test/expected/test-batch_mode.out
+++ b/src/test/expected/test-batch_mode.out
@@ -1,5 +1,4 @@
 VACUUM events;
-SET zdb.batch_mode TO ON;
 BEGIN;
 UPDATE events SET id = id WHERE id = 1;
 UPDATE events SET id = id WHERE id = 2;

--- a/src/test/expected/test-copy.out
+++ b/src/test/expected/test-copy.out
@@ -25,13 +25,9 @@ SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDE
     9
 (9 rows)
 
-/*
- test it with batch mode off (the default) in a transaction
- We should see the results from the select
- */
+/* Within the transaction We should see the results from the select */
 TRUNCATE TABLE copy_test;
 BEGIN;
-SET zdb.batch_mode TO off;
 COPY copy_test(pkey) FROM STDIN;
 SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDER BY pkey;
  pkey 
@@ -42,20 +38,7 @@ SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDE
 (3 rows)
 
 COMMIT;
-/*
- test it with batch mode on in a transaction
- We should NOT see the results from the select until we commit
- */
-TRUNCATE TABLE copy_test;
-BEGIN;
-SET zdb.batch_mode TO on;
-COPY copy_test(pkey) FROM STDIN;
-SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDER BY pkey;
- pkey 
-------
-(0 rows)
-
-COMMIT;
+/* and we should see the results after the commit */
 SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDER BY pkey;
  pkey 
 ------

--- a/src/test/expected/test-zdbl_visibility_clause.out
+++ b/src/test/expected/test-zdbl_visibility_clause.out
@@ -1,4 +1,4 @@
-select jsonb_pretty(regexp_replace(zdb.visibility_clause(42, 99, 0, ARRAY[1,2,3,4,5]::bigint[], 'idxevents', 'doc')::text, '"index":".*?"', '"index":"xxx"', 'g')::jsonb);
+select jsonb_pretty(regexp_replace(zdb.visibility_clause(ARRAY[42]::bigint[], 99, 0, ARRAY[1,2,3,4,5]::bigint[], 'idxevents', 'doc')::text, '"index":".*?"', '"index":"xxx"', 'g')::jsonb);
                                                         jsonb_pretty                                                         
 -----------------------------------------------------------------------------------------------------------------------------
  {                                                                                                                          +
@@ -22,10 +22,10 @@ select jsonb_pretty(regexp_replace(zdb.visibility_clause(42, 99, 0, ARRAY[1,2,3,
                              "bool": {                                                                                      +
                                  "must": [                                                                                  +
                                      {                                                                                      +
-                                         "term": {                                                                          +
-                                             "zdb_xmin": {                                                                  +
-                                                 "value": 42                                                                +
-                                             }                                                                              +
+                                         "terms": {                                                                         +
+                                             "zdb_xmin": [                                                                  +
+                                                 42                                                                         +
+                                             ]                                                                              +
                                          }                                                                                  +
                                      },                                                                                     +
                                      {                                                                                      +
@@ -53,10 +53,10 @@ select jsonb_pretty(regexp_replace(zdb.visibility_clause(42, 99, 0, ARRAY[1,2,3,
                                                      "bool": {                                                              +
                                                          "must": [                                                          +
                                                              {                                                              +
-                                                                 "term": {                                                  +
-                                                                     "zdb_xmax": {                                          +
-                                                                         "value": 42                                        +
-                                                                     }                                                      +
+                                                                 "terms": {                                                 +
+                                                                     "zdb_xmax": [                                          +
+                                                                         42                                                 +
+                                                                     ]                                                      +
                                                                  }                                                          +
                                                              },                                                             +
                                                              {                                                              +
@@ -145,10 +145,10 @@ select jsonb_pretty(regexp_replace(zdb.visibility_clause(42, 99, 0, ARRAY[1,2,3,
                                                                  "bool": {                                                  +
                                                                      "must": [                                              +
                                                                          {                                                  +
-                                                                             "term": {                                      +
-                                                                                 "zdb_xmax": {                              +
-                                                                                     "value": 42                            +
-                                                                                 }                                          +
+                                                                             "terms": {                                     +
+                                                                                 "zdb_xmax": [                              +
+                                                                                     42                                     +
+                                                                                 ]                                          +
                                                                              }                                              +
                                                                          },                                                 +
                                                                          {                                                  +
@@ -168,10 +168,10 @@ select jsonb_pretty(regexp_replace(zdb.visibility_clause(42, 99, 0, ARRAY[1,2,3,
                                                                              "bool": {                                      +
                                                                                  "must_not": [                              +
                                                                                      {                                      +
-                                                                                         "term": {                          +
-                                                                                             "zdb_xmax": {                  +
-                                                                                                 "value": 42                +
-                                                                                             }                              +
+                                                                                         "terms": {                         +
+                                                                                             "zdb_xmax": [                  +
+                                                                                                 42                         +
+                                                                                             ]                              +
                                                                                          }                                  +
                                                                                      }                                      +
                                                                                  ]                                          +

--- a/src/test/sql/issue-273.sql
+++ b/src/test/sql/issue-273.sql
@@ -13,10 +13,16 @@ commit; -- results in ERROR because "next xid value" doesn't exist in events' li
 
 begin;
 insert into issue273(id) values (2);
+select * from issue273 order by id;
+select * from zdb.terms('idxissue273', 'id', dsl.match_all(), 1000, 'term');
 savepoint three;
 insert into issue273(id) values (3);
+select * from issue273 order by id;
+select * from zdb.terms('idxissue273', 'id', dsl.match_all(), 1000, 'term');
 rollback to three;
 insert into issue273(id) values (4);
+select * from issue273 order by id;
+select * from zdb.terms('idxissue273', 'id', dsl.match_all(), 1000, 'term');
 commit;
 
 select * from issue273 order by id;

--- a/src/test/sql/issue-273.sql
+++ b/src/test/sql/issue-273.sql
@@ -1,0 +1,12 @@
+CREATE TABLE issue273 (
+    id bigint not null primary key,
+    data text
+);
+insert into issue273 (id, data) values (1, 'this is a test');
+create index idxissue273 on issue273 using zombodb ((issue273.*));
+begin;
+select txid_current() is not null;  -- burn current xid
+savepoint foo;
+update issue273 set id = id where id = 1;  -- gets next xid value
+commit; -- results in ERROR because "next xid value" doesn't exist in events' list of aborted xids.
+DROP TABLE issue273;

--- a/src/test/sql/test-batch_mode.sql
+++ b/src/test/sql/test-batch_mode.sql
@@ -1,5 +1,4 @@
 VACUUM events;
-SET zdb.batch_mode TO ON;
 BEGIN;
 UPDATE events SET id = id WHERE id = 1;
 UPDATE events SET id = id WHERE id = 2;

--- a/src/test/sql/test-copy.sql
+++ b/src/test/sql/test-copy.sql
@@ -21,13 +21,9 @@ COPY copy_test(pkey) FROM STDIN;
 
 SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDER BY pkey;
 
-/*
- test it with batch mode off (the default) in a transaction
- We should see the results from the select
- */
+/* Within the transaction We should see the results from the select */
 TRUNCATE TABLE copy_test;
 BEGIN;
-SET zdb.batch_mode TO off;
 COPY copy_test(pkey) FROM STDIN;
 4
 5
@@ -37,22 +33,7 @@ COPY copy_test(pkey) FROM STDIN;
 SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDER BY pkey;
 COMMIT;
 
-
-/*
- test it with batch mode on in a transaction
- We should NOT see the results from the select until we commit
- */
-TRUNCATE TABLE copy_test;
-BEGIN;
-SET zdb.batch_mode TO on;
-COPY copy_test(pkey) FROM STDIN;
-4
-5
-6
-\.
-
-SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDER BY pkey;
-COMMIT;
+/* and we should see the results after the commit */
 SELECT pkey FROM copy_test WHERE copy_test ==> range(field=>'pkey', gte=>0) ORDER BY pkey;
 
 DROP TABLE copy_test;

--- a/src/test/sql/test-zdbl_visibility_clause.sql
+++ b/src/test/sql/test-zdbl_visibility_clause.sql
@@ -1,1 +1,1 @@
-select jsonb_pretty(regexp_replace(zdb.visibility_clause(42, 99, 0, ARRAY[1,2,3,4,5]::bigint[], 'idxevents', 'doc')::text, '"index":".*?"', '"index":"xxx"', 'g')::jsonb);
+select jsonb_pretty(regexp_replace(zdb.visibility_clause(ARRAY[42]::bigint[], 99, 0, ARRAY[1,2,3,4,5]::bigint[], 'idxevents', 'doc')::text, '"index":".*?"', '"index":"xxx"', 'g')::jsonb);

--- a/zombodb.control
+++ b/zombodb.control
@@ -1,6 +1,6 @@
 # ZomboDB extension
 comment = 'ZomboDB:  Making Postgres and Elasticsearch work together like it''s 2018'
-default_version = '10-1.0.0b4'
+default_version = '10-1.0.0b5'
 module_pathname = '$libdir/zombodb'
 relocatable = false
 schema = zdb


### PR DESCRIPTION
This resolves Issue #273 by adding support for `SAVEPOINT` and `ROLLBACK TO`.

It also removes the `zdb.batch_mode` GUC setting as operating in "batch mode" is now what ZDB does all the time.  If in the middle of a transaction ZDB sees that it needs to push current batches to Elasticsearch in order to be able to properly answer a SELECT statement (or any of the zdb.agg() functions) then it does that automatically.