### PR TITLE
Issue 305

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.swp
 .DS_store
 foo.*
-src/sql/zombodb--10-1.0.0b7.sql
+src/sql/zombodb--10-1.0.0b8.sql
 results/
 regression.*
 cmake-build-debug/

--- a/src/c/elasticsearch/elasticsearch.c
+++ b/src/c/elasticsearch/elasticsearch.c
@@ -815,7 +815,7 @@ ElasticsearchScrollContext *ElasticsearchOpenScroll(Relation indexRel, ZDBQueryT
 	context->extraFields   = extraFields;
 	context->nextraFields  = nextraFields;
 
-	if (context->total > 0) {
+	if (offset < context->total) {
 		context->hits  = get_json_object_array(hitsObject, "hits", false);
 		context->nhits = context->hits == NULL ? 0 : get_json_array_length(context->hits);
 
@@ -825,6 +825,13 @@ ElasticsearchScrollContext *ElasticsearchOpenScroll(Relation indexRel, ZDBQueryT
 				ElasticsearchGetNextItemPointer(context, NULL, NULL, NULL, NULL);
 			}
 		}
+	} else {
+		/*
+		 * user specified an offset that's beyond the number of hits actually found, so just
+		 * pretend we don't have any hits at all
+		 */
+		context->total = 0;
+		context->nhits = 0;
 	}
 
 	pfree(queryDSL);

--- a/src/c/zombodb.h
+++ b/src/c/zombodb.h
@@ -32,6 +32,6 @@
 #include "utils/utils.h"
 #include <assert.h>
 
-#define ZDB_VERSION "10-1.0.0b7"
+#define ZDB_VERSION "10-1.0.0b8"
 
 #endif /* __ZDB_ZDB__H__ */

--- a/src/sql/zombodb--10-1.0.0b7--10-1.0.0b8.sql
+++ b/src/sql/zombodb--10-1.0.0b7--10-1.0.0b8.sql
@@ -1,0 +1,1 @@
+-- no sql changes

--- a/src/test/expected/issue-305.out
+++ b/src/test/expected/issue-305.out
@@ -1,0 +1,20 @@
+CREATE TABLE cars (model varchar, id bigint);
+INSERT INTO cars (model, id) VALUES ('ford', 1);
+CREATE INDEX idx_cars ON cars USING zombodb ((cars.*));
+SELECT * FROM cars WHERE cars ==> dsl.offset(0, 'ford');
+ model | id 
+-------+----
+ ford  |  1
+(1 row)
+
+SELECT * FROM cars WHERE cars ==> dsl.offset(1, 'ford');
+ model | id 
+-------+----
+(0 rows)
+
+SELECT * FROM cars WHERE cars ==> dsl.offset(2, 'ford');
+ model | id 
+-------+----
+(0 rows)
+
+DROP TABLE cars;

--- a/src/test/sql/issue-305.sql
+++ b/src/test/sql/issue-305.sql
@@ -1,0 +1,8 @@
+CREATE TABLE cars (model varchar, id bigint);
+INSERT INTO cars (model, id) VALUES ('ford', 1);
+CREATE INDEX idx_cars ON cars USING zombodb ((cars.*));
+SELECT * FROM cars WHERE cars ==> dsl.offset(0, 'ford');
+SELECT * FROM cars WHERE cars ==> dsl.offset(1, 'ford');
+SELECT * FROM cars WHERE cars ==> dsl.offset(2, 'ford');
+
+DROP TABLE cars;

--- a/zombodb.control
+++ b/zombodb.control
@@ -1,6 +1,6 @@
 # ZomboDB extension
 comment = 'ZomboDB:  Making Postgres and Elasticsearch work together like it''s 2018'
-default_version = '10-1.0.0b7'
+default_version = '10-1.0.0b8'
 module_pathname = '$libdir/zombodb'
 relocatable = false
 schema = zdb


### PR DESCRIPTION
This PR resolves #305, which fixes a bug with `dsl.offset()` when the offset value is larger than the total number of records found.