### PR TITLE
Reduce per-SELECT overhead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.swp
 .DS_store
 foo.*
-src/sql/zombodb--10-1.0.1.sql
+src/sql/zombodb--10-1.0.2.sql
 results/
 regression.*
 cmake-build-debug/

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PGFILEDESC = "ZomboDB"
 #
 # object files 
 #
-PG_CPPFLAGS += -Isrc/c/ -O0
+PG_CPPFLAGS += -Isrc/c/
 SHLIB_LINK += -lcurl -lz
 OBJS = $(shell find src/c -type f -name "*.c" | sed s/\\.c/.o/g)
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PGFILEDESC = "ZomboDB"
 #
 # object files 
 #
-PG_CPPFLAGS += -Isrc/c/
+PG_CPPFLAGS += -Isrc/c/ -O0
 SHLIB_LINK += -lcurl -lz
 OBJS = $(shell find src/c -type f -name "*.c" | sed s/\\.c/.o/g)
 

--- a/QUERY-DSL.md
+++ b/QUERY-DSL.md
@@ -548,7 +548,7 @@ The boosting query can be used to effectively demote results that match a given 
 
 ```sql
 FUNCTION dsl.common (
-	field name,
+	field text,
 	query text,
 	boost real DEFAULT NULL,
 	cutoff_frequency real DEFAULT NULL,
@@ -598,7 +598,7 @@ A query that generates the union of documents produced by its subqueries, and th
 
 ```sql
 FUNCTION dsl.field_exists (
-	field name)
+	field text)
 RETURNS zdbquery
 ```
 
@@ -613,7 +613,7 @@ Returns documents that have at least one non-null value in the specified field
 
 ```sql
 FUNCTION dsl.field_missing (
-	field name)
+	field text)
 RETURNS zdbquery
 ```
 
@@ -625,7 +625,7 @@ The inverse of `dsl.field_exists()`.  Returns documents that have no value in th
 
 ```sql
 FUNCTION dsl.fuzzy (
-	field name,
+	field text,
 	value text,
 	boost real DEFAULT NULL,
 	fuzziness integer DEFAULT NULL,
@@ -645,7 +645,7 @@ The fuzzy query uses similarity based on Levenshtein edit distance.
 
 ```sql
 FUNCTION dsl.match (
-	field name,
+	field text,
 	query text,
 	boost real DEFAULT NULL,
 	analyzer text DEFAULT NULL,
@@ -697,7 +697,7 @@ The inverse of `dsl.match_all()`.  Matches no documents.
 
 ```sql
 FUNCTION dsl.match_phrase (
-	field name,
+	field text,
 	query text,
 	boost real DEFAULT NULL,
 	slop integer DEFAULT NULL,
@@ -715,7 +715,7 @@ The `match_phrase` query analyzes the text and creates a phrase query out of the
 
 ```sql
 FUNCTION dsl.match_phrase_prefix (
-	field name,
+	field text,
 	query text,
 	boost real DEFAULT NULL,
 	slop integer DEFAULT NULL,
@@ -735,7 +735,7 @@ https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-
 ```sql
 FUNCTION dsl.more_like_this (
 	"like" text,
-	fields name[] DEFAULT NULL,
+	fields text[] DEFAULT NULL,
 	stop_words text[] DEFAULT ARRAY[...],
 	boost real DEFAULT NULL,
 	unlike text DEFAULT NULL,
@@ -765,7 +765,7 @@ This form takes a single blob of text as the source document.
 ```sql
 FUNCTION dsl.more_like_this (
 	"like" text[],
-	fields name[] DEFAULT NULL,
+	fields text[] DEFAULT NULL,
 	stop_words text[] DEFAULT ARRAY[...],
 	boost real DEFAULT NULL,
 	unlike text DEFAULT NULL,
@@ -795,7 +795,7 @@ This form takes multiple snippets of text as the source documents.
 
 ```sql
 FUNCTION dsl.multi_match (
-	fields name[],
+	fields text[],
 	query text,
 	boost real DEFAULT NULL,
 	type dsl.es_multi_match_type DEFAULT NULL,
@@ -858,7 +858,7 @@ A query that uses a query parser in order to parse its content.  The query_strin
 
 ```sql
 FUNCTION dsl.nested (
-	path name,
+	path text,
 	query zdbquery,
 	score_mode dsl.es_nested_score_mode DEFAULT 'avg'::dsl.es_nested_score_mode)
 RETURNS zdbquery
@@ -886,7 +886,7 @@ Generates a `bool` query where the argument is the only member of the `bool` que
 
 ```sql
 FUNCTION dsl.phrase (
-	field name,
+	field text,
 	query text,
 	boost real DEFAULT NULL,
 	slop integer DEFAULT NULL,
@@ -902,7 +902,7 @@ Short-hand form of `dsl.match_phrase()`.
 
 ```sql
 FUNCTION dsl.prefix (
-	field name,
+	field text,
 	prefix text,
 	boost real DEFAULT NULL)
 RETURNS zdbquery
@@ -918,7 +918,7 @@ Matches documents that have fields containing terms with a specified prefix (not
 
 ```sql
 FUNCTION dsl.range (
-	field name,
+	field text,
 	lt numeric DEFAULT NULL,
 	gt numeric DEFAULT NULL,
 	lte numeric DEFAULT NULL,
@@ -937,7 +937,7 @@ Matches documents with fields that have terms within a certain range.  This form
 
 ```sql
 FUNCTION dsl.range (
-	field name,
+	field text,
 	lt text DEFAULT NULL,
 	gt text DEFAULT NULL,
 	lte text DEFAULT NULL,
@@ -957,7 +957,7 @@ Matches documents with fields that have terms within a certain range.  This form
 
 ```sql
 FUNCTION dsl.regexp (
-	field name,
+	field text,
 	regexp text,
 	boost real DEFAULT NULL,
 	flags dsl.es_regexp_flags[] DEFAULT NULL,
@@ -1021,7 +1021,7 @@ Matches spans near the beginning of a field.
 
 ```sql
 FUNCTION dsl.span_masking (
-	field name,
+	field text,
 	query zdbquery)
 RETURNS zdbquery
 ```
@@ -1098,7 +1098,7 @@ Matches the union of its span clauses.
 
 ```sql
 FUNCTION dsl.span_term (
-	field name,
+	field text,
 	value text,
 	boost real DEFAULT NULL)
 RETURNS zdbquery
@@ -1129,7 +1129,7 @@ Returns matches which are enclosed inside another span query.
 
 ```sql
 FUNCTION dsl.term (
-	field name,
+	field text,
 	value numeric,
 	boost real DEFAULT NULL)
 RETURNS zdbquery
@@ -1145,7 +1145,7 @@ The term query finds documents that contain the **exact** term specified in the 
 
 ```sql
 FUNCTION dsl.term (
-	field name,
+	field text,
 	value text,
 	boost real DEFAULT NULL)
 RETURNS zdbquery
@@ -1162,7 +1162,7 @@ The term query finds documents that contain the **exact** term specified in the 
 
 ```sql
 FUNCTION dsl.terms (
-	field name,
+	field text,
 	VARIADIC "values" numeric[])
 RETURNS zdbquery
 ```
@@ -1177,7 +1177,7 @@ Filters documents that have fields that match any of the provided terms (not ana
 
 ```sql
 FUNCTION dsl.terms (
-	field name,
+	field text,
 	VARIADIC "values" text[])
 RETURNS zdbquery
 ```
@@ -1192,7 +1192,7 @@ Filters documents that have fields that match any of the provided terms (not ana
 
 ```sql
 FUNCTION dsl.terms_array (
-	field name,
+	field text,
 	"values" anyarray)
 RETURNS zdbquery
 ```
@@ -1207,7 +1207,7 @@ Filters documents that have fields that match any of the provided terms (not ana
 
 ```sql
 FUNCTION dsl.terms_lookup (
-	field name,
+	field text,
 	index text,
 	type text,
 	path text,
@@ -1225,7 +1225,7 @@ When it’s needed to specify a terms filter with a lot of terms it can be benef
 
 ```sql
 FUNCTION dsl.wildcard (
-	field name,
+	field text,
 	wildcard text,
 	boost real DEFAULT NULL)
 RETURNS zdbquery

--- a/TYPE-MAPPING.md
+++ b/TYPE-MAPPING.md
@@ -127,7 +127,7 @@ This approach can be quite powerful as you can set, per field, all the mapping p
 
 
 ```sql
-FUNCTION zdb.define_field_mapping(table_name regclass, field_name name, definition json) 
+FUNCTION zdb.define_field_mapping(table_name regclass, field_name text, definition json) 
 ```
 
 If you need to define a field mapping for a specific field in a specific table, this is the function to use.  You can specify any [custom mapping definition json](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-params.html) that is supported by Elasticsearch.
@@ -137,7 +137,7 @@ Creating or changing a field mapping requires a `REINDEX` of the specified table
 ---
 
 ```sql
-FUNCTION zdb.define_es_only_field(table_name regclass, field_name name, definition json)
+FUNCTION zdb.define_es_only_field(table_name regclass, field_name text, definition json)
 ```
 
 If you want a custom field that only exists in the Elasticsearch index (perhaps as a target to the mapping [`copy_to`](https://www.elastic.co/guide/en/elasticsearch/reference/current/copy-to.html) property, you can use this.
@@ -173,7 +173,7 @@ ZomboDB provides a few functions that can be used to evaluate how an analyzer ac
 ```sql
 FUNCTION zdb.analyze_with_field(
 	index regclass, 
-	field name, 
+	field text, 
 	text text) 
 RETURNS TABLE (
 	type text, 

--- a/src/c/elasticsearch/elasticsearch.c
+++ b/src/c/elasticsearch/elasticsearch.c
@@ -704,7 +704,7 @@ uint64 ElasticsearchEstimateSelectivity(Relation indexRel, ZDBQueryType *query) 
 	StringInfo response;
 	Datum      count;
 
-	appendStringInfo(postData, "{\"query\":%s}", convert_to_query_dsl(indexRel, query));
+	appendStringInfo(postData, "{\"query\":%s}", convert_to_query_dsl(indexRel, query, false));
 	appendStringInfo(request,
 					 "%s%s/%s/_count?filter_path=count",
 					 ZDBIndexOptionsGetUrl(indexRel), ZDBIndexOptionsGetIndexName(indexRel),
@@ -719,7 +719,7 @@ uint64 ElasticsearchEstimateSelectivity(Relation indexRel, ZDBQueryType *query) 
 
 ElasticsearchScrollContext *ElasticsearchOpenScroll(Relation indexRel, ZDBQueryType *userQuery, bool use_id, uint64 limit, List *highlights, char **extraFields, int nextraFields) {
 	ElasticsearchScrollContext *context       = palloc0(sizeof(ElasticsearchScrollContext));
-	char                       *queryDSL      = convert_to_query_dsl(indexRel, userQuery);
+    char                       *queryDSL;
 	StringInfo                 request        = makeStringInfo();
 	StringInfo                 postData       = makeStringInfo();
 	StringInfo                 docvalueFields = makeStringInfo();
@@ -741,7 +741,9 @@ ElasticsearchScrollContext *ElasticsearchOpenScroll(Relation indexRel, ZDBQueryT
 	sortJson  = zdbquery_get_sort_json(userQuery);
 	min_score = zdbquery_get_min_score(userQuery);
 
-	/* we'll assume we want scoring if we have a limit w/o a sort, so that we get the top scoring docs when the limit is applied */
+    queryDSL = convert_to_query_dsl(indexRel, userQuery, limit > 0);
+
+    /* we'll assume we want scoring if we have a limit w/o a sort, so that we get the top scoring docs when the limit is applied */
 	needScore = needScore || (limit > 0 && sortJson == NULL);
 
 	appendStringInfo(postData, "{\"track_scores\":%s,", needScore ? "true" : "false");
@@ -981,7 +983,7 @@ char *ElasticsearchProfileQuery(Relation indexRel, ZDBQueryType *query) {
 	StringInfo postData = makeStringInfo();
 	StringInfo response;
 
-	appendStringInfo(postData, "{\"profile\":true, \"query\":%s}", convert_to_query_dsl(indexRel, query));
+	appendStringInfo(postData, "{\"profile\":true, \"query\":%s}", convert_to_query_dsl(indexRel, query, false));
 
 	appendStringInfo(request, "%s%s/_search?size=0&filter_path=profile&pretty", ZDBIndexOptionsGetUrl(indexRel),
 					 ZDBIndexOptionsGetIndexName(indexRel));
@@ -1004,7 +1006,7 @@ uint64 ElasticsearchCount(Relation indexRel, ZDBQueryType *query) {
 
 	finish_inserts(false);
 
-	appendStringInfo(postData, "{\"query\":%s}", convert_to_query_dsl(indexRel, query));
+	appendStringInfo(postData, "{\"query\":%s}", convert_to_query_dsl(indexRel, query, true));
 
 	appendStringInfo(request, "%s%s/_count?filter_path=count", ZDBIndexOptionsGetUrl(indexRel),
 					 ZDBIndexOptionsGetAlias(indexRel));
@@ -1031,7 +1033,7 @@ static char *makeAggRequest(Relation indexRel, ZDBQueryType *query, char *agg, b
 
 	appendStringInfoCharMacro(postData, '{');
 	if (query != NULL)
-		appendStringInfo(postData, "\"query\":%s,", convert_to_query_dsl(indexRel, query));
+		appendStringInfo(postData, "\"query\":%s,", convert_to_query_dsl(indexRel, query, true));
 
 	if (arbitrary) {
 		appendStringInfo(postData, "\"aggs\":%s", agg);
@@ -1101,7 +1103,7 @@ static StringInfo terms_agg_only_keys(Relation indexRel, char *field, ZDBQueryTy
 
 	appendStringInfoCharMacro(postData, '{');
 	if (query != NULL)
-		appendStringInfo(postData, "\"query\":%s,", convert_to_query_dsl(indexRel, query));
+		appendStringInfo(postData, "\"query\":%s,", convert_to_query_dsl(indexRel, query, true));
 
 	appendStringInfo(postData, "\"aggs\":{\"the_agg\":{\"terms\":{\"field\":\"%s\",\"size\":%lu%s}}}", field, size,
 					 orderClause);
@@ -1271,7 +1273,7 @@ char *ElasticsearchFilters(Relation indexRel, char **labels, ZDBQueryType **filt
 	appendStringInfo(agg, "{\"filters\":{\"filters\":{");
 	for (i = 0; i < nfilters; i++) {
 		if (i > 0) appendStringInfoCharMacro(agg, ',');
-		appendStringInfo(agg, "\"%s\":%s", labels[i], convert_to_query_dsl(indexRel, filters[i]));
+		appendStringInfo(agg, "\"%s\":%s", labels[i], convert_to_query_dsl(indexRel, filters[i], true));
 	}
 	appendStringInfo(agg, "}}}");
 
@@ -1305,7 +1307,7 @@ char *ElasticsearchAdjacencyMatrix(Relation indexRel, char **labels, ZDBQueryTyp
 	appendStringInfo(agg, "{\"adjacency_matrix\":{\"filters\":{");
 	for (i = 0; i < nfilters; i++) {
 		if (i > 0) appendStringInfoCharMacro(agg, ',');
-		appendStringInfo(agg, "\"%s\":%s", labels[i], convert_to_query_dsl(indexRel, filters[i]));
+		appendStringInfo(agg, "\"%s\":%s", labels[i], convert_to_query_dsl(indexRel, filters[i], true));
 	}
 	appendStringInfo(agg, "}}}");
 

--- a/src/c/elasticsearch/elasticsearch.h
+++ b/src/c/elasticsearch/elasticsearch.h
@@ -98,7 +98,8 @@ uint64 ElasticsearchCountAllDocs(Relation indexRel);
 uint64 ElasticsearchEstimateSelectivity(Relation indexRel, ZDBQueryType *query);
 
 ElasticsearchScrollContext *ElasticsearchOpenScroll(Relation indexRel, ZDBQueryType *userQuery, bool use_id, uint64 limit, List *highlights, char **extraFields, int nextraFields);
-void ElasticsearchGetNextItemPointer(ElasticsearchScrollContext *context, ItemPointer ctid, char **_id, float4 *score, zdb_json_object *highlights);
+bool ElasticsearchGetNextItemPointer(ElasticsearchScrollContext *context, ItemPointer ctid, char **_id, float4 *score,
+									 zdb_json_object *highlights);
 void ElasticsearchCloseScroll(ElasticsearchScrollContext *scrollContext);
 
 void ElasticsearchRemoveAbortedTransactions(Relation indexRel, List/*uint64*/ *xids);

--- a/src/c/elasticsearch/querygen.h
+++ b/src/c/elasticsearch/querygen.h
@@ -20,7 +20,7 @@
 #include "zombodb.h"
 
 char *convert_to_query_dsl_not_wrapped(char *input);
-char *convert_to_query_dsl(Relation indexRel, ZDBQueryType *query);
+char *convert_to_query_dsl(Relation indexRel, ZDBQueryType *query, bool apply_visibility);
 ZDBQueryType *array_to_should_query_dsl(ArrayType *array);
 ZDBQueryType *array_to_must_query_dsl(ArrayType *array);
 ZDBQueryType *array_to_not_query_dsl(ArrayType *array);

--- a/src/c/highlighting/highlighting.h
+++ b/src/c/highlighting/highlighting.h
@@ -25,9 +25,14 @@ typedef struct ZDBHighlightInfo {
 	char *json;
 } ZDBHighlightInfo;
 
+#define HIGHLIGHT_FIELD_MAX_LENGTH 8192
+typedef struct ZDBHighlightFieldnameData {
+	char data[HIGHLIGHT_FIELD_MAX_LENGTH];
+} ZDBHighlightFieldnameData;
+
 typedef struct ZDBHighlightKey {
 	ItemPointerData ctid;
-	NameData        field;
+	ZDBHighlightFieldnameData field;
 } ZDBHighlightKey;
 
 typedef struct ZDBHighlightEntry {
@@ -35,7 +40,7 @@ typedef struct ZDBHighlightEntry {
 	List            *highlights;
 } ZDBHighlightEntry;
 
-typedef List *(*highlight_lookup_callback)(ItemPointer ctid, Name field, void *arg);
+typedef List *(*highlight_lookup_callback)(ItemPointer ctid, ZDBHighlightFieldnameData *field, void *arg);
 
 void highlight_support_init(void);
 void highlight_support_cleanup(void);

--- a/src/c/indexam/seqscan.c
+++ b/src/c/indexam/seqscan.c
@@ -99,7 +99,8 @@ static HTAB *create_ctid_map(Relation heapRel, Relation indexRel, ZDBQueryType *
 		float4          score;
 		zdb_json_object highlights;
 
-		ElasticsearchGetNextItemPointer(scroll, &key.ctid, NULL, &score, &highlights);
+		if (!ElasticsearchGetNextItemPointer(scroll, &key.ctid, NULL, &score, &highlights))
+			break;
 
 		entry = hash_search(scoreHash, &key, HASH_ENTER, &found);
 		entry->score = score;

--- a/src/c/indexam/seqscan.c
+++ b/src/c/indexam/seqscan.c
@@ -61,7 +61,7 @@ static float4 scoring_cb(ItemPointer ctid, void *arg) {
 	return 0.0;
 }
 
-static List *highlight_cb(ItemPointer ctid, Name field, void *arg) {
+static List *highlight_cb(ItemPointer ctid, ZDBHighlightFieldnameData *field, void *arg) {
 	HTAB              *hash = (HTAB *) arg;
 	ZDBHighlightKey   key;
 	ZDBHighlightEntry *entry;
@@ -71,7 +71,7 @@ static List *highlight_cb(ItemPointer ctid, Name field, void *arg) {
 	assert(field != NULL);
 
 	memset(&key, 0, sizeof(ZDBHighlightKey));
-	memcpy(&key.field, field, NAMEDATALEN);
+	memcpy(&key.field.data, field->data, HIGHLIGHT_FIELD_MAX_LENGTH);
 	ItemPointerCopy(ctid, &key.ctid);
 
 	entry = hash_search(hash, &key, HASH_FIND, &found);

--- a/src/c/indexam/zdb_index_options.h
+++ b/src/c/indexam/zdb_index_options.h
@@ -50,6 +50,7 @@ typedef struct {
 extern char *zdb_default_elasticsearch_url_guc;
 extern int  zdb_default_row_estimation_guc;
 extern int  zdb_default_replicas_guc;
+extern bool zdb_is_performing_vacuum;
 
 static inline char *ZDBIndexOptionsGetUrl(Relation rel) {
 	char *url = ZDBIndexOptionsGetUrlMacro(rel);

--- a/src/c/indexam/zdb_index_options.h
+++ b/src/c/indexam/zdb_index_options.h
@@ -50,7 +50,6 @@ typedef struct {
 extern char *zdb_default_elasticsearch_url_guc;
 extern int  zdb_default_row_estimation_guc;
 extern int  zdb_default_replicas_guc;
-extern bool zdb_is_performing_vacuum;
 
 static inline char *ZDBIndexOptionsGetUrl(Relation rel) {
 	char *url = ZDBIndexOptionsGetUrlMacro(rel);

--- a/src/c/indexam/zdbam.c
+++ b/src/c/indexam/zdbam.c
@@ -1611,7 +1611,7 @@ static float4 scoring_cb(ItemPointer ctid, void *arg) {
 	return 0;
 }
 
-static List *highlight_cb(ItemPointer ctid, Name field, void *arg) {
+static List *highlight_cb(ItemPointer ctid, ZDBHighlightFieldnameData *field, void *arg) {
 	ZDBScanContext *context = (ZDBScanContext *) arg;
 
 	assert(ctid != NULL);
@@ -1624,7 +1624,7 @@ static List *highlight_cb(ItemPointer ctid, Name field, void *arg) {
 
 		memset(&key, 0, sizeof(ZDBHighlightKey));
 		ItemPointerCopy(ctid, &key.ctid);
-		memcpy(&key.field, field, sizeof(NameData));
+		memcpy(&key.field.data, field->data, HIGHLIGHT_FIELD_MAX_LENGTH);
 
 		entry = hash_search(context->highlightLookup, &key, HASH_FIND, &found);
 		if (entry != NULL && found)

--- a/src/c/indexam/zdbam.c
+++ b/src/c/indexam/zdbam.c
@@ -200,6 +200,8 @@ static ProcessUtility_hook_type prev_ProcessUtilityHook = NULL;
 static planner_hook_type        prev_PlannerHook        = NULL;
 static int                      executor_depth          = 0;
 
+bool zdb_is_performing_vacuum = false;
+
 int  ZDB_LOG_LEVEL;
 char *zdb_default_elasticsearch_url_guc;
 int  zdb_default_row_estimation_guc;
@@ -1328,6 +1330,7 @@ static IndexBulkDeleteResult *zdb_vacuum_internal(IndexVacuumInfo *info, IndexBu
 				int                        deleted = 0, xmaxes_reset = 0;
 
 				zdb_ignore_visibility_guc = true;
+                zdb_is_performing_vacuum  = true;
 
 				if (strcmp(ZDBIndexOptionsGetRefreshInterval(info->index), "-1") != 0) {
 					/*
@@ -1481,10 +1484,12 @@ static IndexBulkDeleteResult *zdb_vacuum_internal(IndexVacuumInfo *info, IndexBu
 				}
 
 				zdb_ignore_visibility_guc = savedIgnoreVisibility;
+                zdb_is_performing_vacuum  = false;
 			}
 		PG_CATCH();
 			{
 				zdb_ignore_visibility_guc = savedIgnoreVisibility;
+                zdb_is_performing_vacuum  = false;
 				PG_RE_THROW();
 			}
 	PG_END_TRY();

--- a/src/c/zombodb.h
+++ b/src/c/zombodb.h
@@ -32,6 +32,6 @@
 #include "utils/utils.h"
 #include <assert.h>
 
-#define ZDB_VERSION "10-1.0.1"
+#define ZDB_VERSION "10-1.0.2"
 
 #endif /* __ZDB_ZDB__H__ */

--- a/src/sql/analyze-support.sql
+++ b/src/sql/analyze-support.sql
@@ -17,7 +17,7 @@ CREATE OR REPLACE FUNCTION analyze_custom(index regclass, text text DEFAULT NULL
            (tokens->>'end_offset')::int
       FROM jsonb_array_elements((zdb.request(index, '_analyze', 'GET', json_strip_nulls(json_build_object('tokenizer', tokenizer, 'normalizer', normalizer, 'text', text, 'filter', filter, 'char_filter', char_filter))::text)::jsonb)->'tokens') tokens;
 $$;
-CREATE OR REPLACE FUNCTION analyze_with_field(index regclass, field name, text text) RETURNS TABLE (type text, token text, "position" int, start_offset int, end_offset int) PARALLEL SAFE IMMUTABLE STRICT LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION analyze_with_field(index regclass, field text, text text) RETURNS TABLE (type text, token text, "position" int, start_offset int, end_offset int) PARALLEL SAFE IMMUTABLE STRICT LANGUAGE sql AS $$
     SELECT tokens->>'type',
            tokens->>'token',
            (tokens->>'position')::int,

--- a/src/sql/highlight-support.sql
+++ b/src/sql/highlight-support.sql
@@ -62,4 +62,4 @@ CREATE OR REPLACE FUNCTION highlight(
         )::zdb.esqdsl_highlight)
     );
 $$;
-CREATE OR REPLACE FUNCTION highlight(ctid tid, field name, highlight_definition json DEFAULT highlight()) RETURNS text[] PARALLEL UNSAFE STABLE STRICT LANGUAGE c AS 'MODULE_PATHNAME', 'zdb_highlight';
+CREATE OR REPLACE FUNCTION highlight(ctid tid, field text, highlight_definition json DEFAULT highlight()) RETURNS text[] PARALLEL UNSAFE STABLE STRICT LANGUAGE c AS 'MODULE_PATHNAME', 'zdb_highlight';

--- a/src/sql/join-support.sql
+++ b/src/sql/join-support.sql
@@ -1,7 +1,7 @@
 --
 -- simple cross-index join support... requires both dsl and agg functions already created
 --
-CREATE OR REPLACE FUNCTION dsl.join(left_field name, index regclass, right_field name, query zdbquery, size int DEFAULT 0) RETURNS zdbquery PARALLEL SAFE STABLE LANGUAGE plpgsql AS $$
+CREATE OR REPLACE FUNCTION dsl.join(left_field text, index regclass, right_field text, query zdbquery, size int DEFAULT 0) RETURNS zdbquery PARALLEL SAFE STABLE LANGUAGE plpgsql AS $$
 BEGIN
     IF size > 0 THEN
         /* if we have a size limit, then limit to the top matching hits */

--- a/src/sql/mapping.sql
+++ b/src/sql/mapping.sql
@@ -32,7 +32,7 @@ CREATE TABLE normalizers (
 
 CREATE TABLE mappings (
   table_name regclass NOT NULL,
-  field_name name NOT NULL,
+  field_name text NOT NULL,
   definition jsonb NOT NULL,
   es_only boolean NOT NULL DEFAULT false,
   PRIMARY KEY (table_name, field_name)
@@ -77,12 +77,12 @@ CREATE OR REPLACE FUNCTION define_normalizer(name text, definition json) RETURNS
   INSERT INTO zdb.normalizers(name, definition) VALUES ($1, $2);
 $$;
 
-CREATE OR REPLACE FUNCTION  define_field_mapping(table_name regclass, field_name name, definition json) RETURNS void LANGUAGE sql VOLATILE STRICT AS $$
+CREATE OR REPLACE FUNCTION define_field_mapping(table_name regclass, field_name text, definition json) RETURNS void LANGUAGE sql VOLATILE STRICT AS $$
   DELETE FROM zdb.mappings WHERE table_name = $1 AND field_name = $2;
   INSERT INTO zdb.mappings(table_name, field_name, definition) VALUES ($1, $2, $3);
 $$;
 
-CREATE OR REPLACE FUNCTION define_es_only_field(table_name regclass, field_name name, definition json) RETURNS void LANGUAGE sql VOLATILE STRICT AS $$
+CREATE OR REPLACE FUNCTION define_es_only_field(table_name regclass, field_name text, definition json) RETURNS void LANGUAGE sql VOLATILE STRICT AS $$
   DELETE FROM zdb.mappings WHERE table_name = $1 AND field_name = $2;
   INSERT INTO zdb.mappings(table_name, field_name, definition, es_only) VALUES ($1, $2, $3, true);
 $$;

--- a/src/sql/query-dsl.sql
+++ b/src/sql/query-dsl.sql
@@ -123,37 +123,37 @@ $$;
 
 CREATE TYPE dsl.esqdsl_term_text AS (value text, boost real);
 CREATE TYPE dsl.esqdsl_term_numeric AS (value numeric, boost real);
-CREATE OR REPLACE FUNCTION dsl.term(field name, value text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.term(field text, value text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('term', json_build_object(field, ROW(value, boost)::dsl.esqdsl_term_text)))::zdbquery;
 $$;
-CREATE OR REPLACE FUNCTION dsl.term(field name, value numeric, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.term(field text, value numeric, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('term', json_build_object(field, ROW(value, boost)::dsl.esqdsl_term_numeric)))::zdbquery;
 $$;
 
 
-CREATE OR REPLACE FUNCTION dsl.terms(field name, VARIADIC "values" text[]) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.terms(field text, VARIADIC "values" text[]) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, "values")))::zdbquery;
 $$;
-CREATE OR REPLACE FUNCTION dsl.terms(field name, VARIADIC "values" numeric[]) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.terms(field text, VARIADIC "values" numeric[]) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, "values")))::zdbquery;
 $$;
-CREATE OR REPLACE FUNCTION dsl.terms_array(field name, "values" anyarray) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.terms_array(field text, "values" anyarray) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, "values")))::zdbquery;
 $$;
 
 
 CREATE TYPE dsl.esqdsl_terms_lookup AS (index text, type text, path text, id text);
-CREATE OR REPLACE FUNCTION dsl.terms_lookup(field name, index text, type text, path text, id text) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.terms_lookup(field text, index text, type text, path text, id text) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, ROW(index, type, path, id)::dsl.esqdsl_terms_lookup)))::zdbquery;
 $$;
 
 
 CREATE TYPE dsl.esqdsl_range_text AS (lt text, gt text, lte text, gte text, boost real);
 CREATE TYPE dsl.esqdsl_range_numeric AS (lt numeric, gt numeric, lte numeric, gte numeric, boost real);
-CREATE OR REPLACE FUNCTION dsl.range(field name, lt text DEFAULT NULL, gt text DEFAULT NULL, lte text DEFAULT NULL, gte text DEFAULT NULL, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.range(field text, lt text DEFAULT NULL, gt text DEFAULT NULL, lte text DEFAULT NULL, gte text DEFAULT NULL, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('range', json_build_object(field, ROW(lt, gt, lte, gte, boost)::dsl.esqdsl_range_text)))::zdbquery;
 $$;
-CREATE OR REPLACE FUNCTION dsl.range(field name, lt numeric DEFAULT NULL, gt numeric DEFAULT NULL, lte numeric DEFAULT NULL, gte numeric DEFAULT NULL, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.range(field text, lt numeric DEFAULT NULL, gt numeric DEFAULT NULL, lte numeric DEFAULT NULL, gte numeric DEFAULT NULL, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('range', json_build_object(field, ROW(lt, gt, lte, gte, boost)::dsl.esqdsl_range_text)))::zdbquery;
 $$;
 
@@ -168,26 +168,26 @@ $$;
 
 
 CREATE TYPE dsl.esqdsl_prefix AS (value text, boost real);
-CREATE OR REPLACE FUNCTION dsl.prefix(field name, prefix text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.prefix(field text, prefix text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('prefix', json_build_object(field, ROW(prefix, boost)::dsl.esqdsl_prefix)))::zdbquery;
 $$;
 
 
 CREATE TYPE dsl.esqdsl_wildcard AS (value text, boost real);
-CREATE OR REPLACE FUNCTION dsl.wildcard(field name, wildcard text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.wildcard(field text, wildcard text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('wildcard', json_build_object(field, ROW(wildcard, boost)::dsl.esqdsl_wildcard)))::zdbquery;
 $$;
 
 
 CREATE TYPE dsl.es_regexp_flags AS ENUM ('ALL', 'ANYSTRING', 'COMPLEMENT', 'EMPTY', 'INTERSECTION', 'INTERVAL', 'NONE');
 CREATE TYPE dsl.esqdsl_regexp AS (value text, flags text, max_determined_states int, boost real);
-CREATE OR REPLACE FUNCTION dsl.regexp(field name, regexp text, boost real DEFAULT NULL, flags dsl.es_regexp_flags[] DEFAULT NULL, max_determinized_states int DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.regexp(field text, regexp text, boost real DEFAULT NULL, flags dsl.es_regexp_flags[] DEFAULT NULL, max_determinized_states int DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('regexp', json_build_object(field, ROW(regexp, (SELECT array_to_string(array_agg(DISTINCT flag), '|') FROM unnest(flags) flag), max_determinized_states, boost)::dsl.esqdsl_regexp)))::zdbquery;
 $$;
 
 
 CREATE TYPE dsl.esqdsl_fuzzy AS (value text, boost real, fuzziness int, prefix_length int, max_expansions int, transpositions boolean);
-CREATE OR REPLACE FUNCTION dsl.fuzzy(field name, value text, boost real DEFAULT NULL, fuzziness int DEFAULT NULL, prefix_length int DEFAULT NULL, max_expansions int DEFAULT NULL, transpositions boolean DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.fuzzy(field text, value text, boost real DEFAULT NULL, fuzziness int DEFAULT NULL, prefix_length int DEFAULT NULL, max_expansions int DEFAULT NULL, transpositions boolean DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('fuzzy', json_build_object(field, ROW(value, boost, fuzziness, prefix_length, max_expansions, transpositions)::dsl.esqdsl_fuzzy)))::zdbquery;
 $$;
 
@@ -195,22 +195,22 @@ $$;
 CREATE TYPE dsl.es_match_zero_terms_query AS ENUM ('none', 'all');
 CREATE TYPE dsl.es_match_operator AS ENUM ('and', 'or');
 CREATE TYPE dsl.esqdsl_match AS (query text, boost real, analyzer text, minimum_should_match text, lenient boolean, fuzziness int, fuzzy_rewrite text, fuzzy_transpositions boolean, prefix_length int, zero_terms_query dsl.es_match_zero_terms_query, cutoff_frequency real, operator dsl.es_match_operator, auto_generate_synonyms_phrase_query boolean);
-CREATE OR REPLACE FUNCTION dsl.match(field name, query text, boost real DEFAULT NULL, analyzer text DEFAULT NULL, minimum_should_match text DEFAULT NULL, lenient boolean DEFAULT NULL, fuzziness int DEFAULT NULL, fuzzy_rewrite text DEFAULT NULL, fuzzy_transpositions boolean DEFAULT NULL, prefix_length int DEFAULT NULL, zero_terms_query dsl.es_match_zero_terms_query DEFAULT NULL, cutoff_frequency real DEFAULT NULL, operator dsl.es_match_operator DEFAULT NULL, auto_generate_synonyms_phrase_query boolean DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.match(field text, query text, boost real DEFAULT NULL, analyzer text DEFAULT NULL, minimum_should_match text DEFAULT NULL, lenient boolean DEFAULT NULL, fuzziness int DEFAULT NULL, fuzzy_rewrite text DEFAULT NULL, fuzzy_transpositions boolean DEFAULT NULL, prefix_length int DEFAULT NULL, zero_terms_query dsl.es_match_zero_terms_query DEFAULT NULL, cutoff_frequency real DEFAULT NULL, operator dsl.es_match_operator DEFAULT NULL, auto_generate_synonyms_phrase_query boolean DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('match', json_build_object(field, ROW(query, boost, analyzer, minimum_should_match, lenient, fuzziness, fuzzy_rewrite, fuzzy_transpositions, prefix_length, zero_terms_query, cutoff_frequency, operator, auto_generate_synonyms_phrase_query)::dsl.esqdsl_match)))::zdbquery;
 $$;
 
 
 CREATE TYPE dsl.esqdsl_match_phrase AS (query text, boost real, slop int, analyzer text);
-CREATE OR REPLACE FUNCTION dsl.match_phrase(field name, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.match_phrase(field text, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('match_phrase', json_build_object(field, ROW(query, boost, slop, analyzer)::dsl.esqdsl_match_phrase)))::zdbquery;
 $$;
-CREATE OR REPLACE FUNCTION dsl.phrase(field name, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.phrase(field text, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT dsl.match_phrase(field, query, boost, slop, analyzer);
 $$;
 
 
 CREATE TYPE dsl.esqdsl_match_phrase_prefix AS (query text, boost real, slop int, analyzer text, max_expansions int);
-CREATE OR REPLACE FUNCTION dsl.match_phrase_prefix(field name, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL, max_expansions int DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.match_phrase_prefix(field text, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL, max_expansions int DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('match_phrase_prefix', json_build_object(field, ROW(query, boost, slop, analyzer, max_expansions)::dsl.esqdsl_match_phrase_prefix)))::zdbquery;
 $$;
 
@@ -223,7 +223,7 @@ $$;
 
 
 CREATE TYPE dsl.esqdsl_common AS (query text, boost real, cutoff_frequency real, analyzer text, minimum_should_match text);
-CREATE OR REPLACE FUNCTION dsl.common(field name, query text, boost real DEFAULT NULL, cutoff_frequency real DEFAULT NULL, analyzer text DEFAULT NULL, minimum_should_match text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.common(field text, query text, boost real DEFAULT NULL, cutoff_frequency real DEFAULT NULL, analyzer text DEFAULT NULL, minimum_should_match text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('common', json_build_object(field, ROW(query, boost, cutoff_frequency, analyzer, minimum_should_match)::dsl.esqdsl_common)))::zdbquery;
 $$;
 
@@ -278,12 +278,12 @@ CREATE OR REPLACE FUNCTION dsl.boosting(positive zdbquery, negative zdbquery, ne
 $$;
 
 CREATE TYPE dsl.es_nested_score_mode AS ENUM ('avg', 'sum', 'min', 'max', 'none');
-CREATE TYPE dsl.esqdsl_nested AS (path name, query zdbquery, score_mode dsl.es_nested_score_mode);
-CREATE OR REPLACE FUNCTION dsl.nested(path name, query zdbquery, score_mode dsl.es_nested_score_mode DEFAULT 'avg'::dsl.es_nested_score_mode) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE TYPE dsl.esqdsl_nested AS (path text, query zdbquery, score_mode dsl.es_nested_score_mode);
+CREATE OR REPLACE FUNCTION dsl.nested(path text, query zdbquery, score_mode dsl.es_nested_score_mode DEFAULT 'avg'::dsl.es_nested_score_mode) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('nested', ROW(path, query, score_mode)::dsl.esqdsl_nested))::zdbquery;
 $$;
 
-CREATE OR REPLACE FUNCTION dsl.span_term(field name, value text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.span_term(field text, value text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('span_term', json_build_object(field, ROW(value, boost)::dsl.esqdsl_term_text)))::zdbquery;
 $$;
 CREATE OR REPLACE FUNCTION dsl.span_multi(query zdbquery) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
@@ -311,7 +311,7 @@ $$;
 CREATE OR REPLACE FUNCTION dsl.span_within(little zdbquery, big zdbquery) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('span_within', json_build_object('little', little, 'big', big)))::zdbquery;
 $$;
-CREATE OR REPLACE FUNCTION dsl.span_masking(field name, query zdbquery) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+CREATE OR REPLACE FUNCTION dsl.span_masking(field text, query zdbquery) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
     SELECT json_strip_nulls(json_build_object('field_masking_span', json_build_object('query', query, 'field', field)))::zdbquery;
 $$;
 

--- a/src/sql/zombodb--10-1.0.1--10-1.0.2.sql
+++ b/src/sql/zombodb--10-1.0.1--10-1.0.2.sql
@@ -1,0 +1,150 @@
+-- drop all the functions we're about to replace
+DROP FUNCTION zdb.analyze_with_field;
+DROP FUNCTION zdb.define_field_mapping;
+DROP FUNCTION zdb.define_es_only_field;
+DROP FUNCTION dsl.join;
+
+DROP FUNCTION dsl.term(name, text, real);
+DROP FUNCTION dsl.term(name, numeric, real);
+DROP FUNCTION dsl.terms(name, VARIADIC text[]);
+DROP FUNCTION dsl.terms(name, VARIADIC numeric[]);
+DROP FUNCTION dsl.terms_array;
+DROP FUNCTION dsl.terms_lookup;
+DROP FUNCTION dsl.range(name, numeric, numeric, numeric, numeric, real);
+DROP FUNCTION dsl.range(name, text, text, text, text, real);
+DROP FUNCTION dsl.prefix;
+DROP FUNCTION dsl.wildcard;
+DROP FUNCTION dsl.regexp;
+DROP FUNCTION dsl.fuzzy;
+DROP FUNCTION dsl.match;
+DROP FUNCTION dsl.match_phrase;
+DROP FUNCTION dsl.phrase;
+DROP FUNCTION dsl.match_phrase_prefix;
+DROP FUNCTION dsl.common;
+DROP FUNCTION dsl.nested;
+DROP FUNCTION dsl.span_term;
+DROP FUNCTION dsl.span_masking;
+DROP TYPE dsl.esqdsl_nested;
+
+--
+-- replace functions and types
+--
+
+ALTER TABLE zdb.mappings ALTER COLUMN field_name TYPE text USING field_name::text;
+
+CREATE OR REPLACE FUNCTION zdb.analyze_with_field(index regclass, field text, text text) RETURNS TABLE (type text, token text, "position" int, start_offset int, end_offset int) PARALLEL SAFE IMMUTABLE STRICT LANGUAGE sql AS $$
+    SELECT tokens->>'type',
+           tokens->>'token',
+           (tokens->>'position')::int,
+           (tokens->>'start_offset')::int,
+           (tokens->>'end_offset')::int
+      FROM jsonb_array_elements((zdb.request(index, '_analyze', 'GET', json_build_object('field', field, 'text', text)::text)::jsonb)->'tokens') tokens;
+$$;
+
+CREATE OR REPLACE FUNCTION zdb.define_field_mapping(table_name regclass, field_name text, definition json) RETURNS void LANGUAGE sql VOLATILE STRICT AS $$
+  DELETE FROM zdb.mappings WHERE table_name = $1 AND field_name = $2;
+  INSERT INTO zdb.mappings(table_name, field_name, definition) VALUES ($1, $2, $3);
+$$;
+
+CREATE OR REPLACE FUNCTION zdb.define_es_only_field(table_name regclass, field_name text, definition json) RETURNS void LANGUAGE sql VOLATILE STRICT AS $$
+  DELETE FROM zdb.mappings WHERE table_name = $1 AND field_name = $2;
+  INSERT INTO zdb.mappings(table_name, field_name, definition, es_only) VALUES ($1, $2, $3, true);
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.join(left_field text, index regclass, right_field text, query zdbquery, size int DEFAULT 0) RETURNS zdbquery PARALLEL SAFE STABLE LANGUAGE plpgsql AS $$
+BEGIN
+    IF size > 0 THEN
+        /* if we have a size limit, then limit to the top matching hits */
+        RETURN dsl.filter(dsl.terms(left_field, VARIADIC (SELECT array_agg(source->>right_field) FROM zdb.top_hits(index, ARRAY[right_field], query, size))));
+    ELSE
+        /* otherwise, return all the matching terms */
+        RETURN dsl.filter(dsl.terms(left_field, VARIADIC zdb.terms_array(index, right_field, query)));
+    END IF;
+END;
+$$;
+
+-- query dsl changed
+
+CREATE OR REPLACE FUNCTION dsl.term(field text, value text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('term', json_build_object(field, ROW(value, boost)::dsl.esqdsl_term_text)))::zdbquery;
+$$;
+CREATE OR REPLACE FUNCTION dsl.term(field text, value numeric, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('term', json_build_object(field, ROW(value, boost)::dsl.esqdsl_term_numeric)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.terms(field text, VARIADIC "values" text[]) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, "values")))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.terms(field text, VARIADIC "values" numeric[]) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, "values")))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.terms_array(field text, "values" anyarray) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, "values")))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.terms_lookup(field text, index text, type text, path text, id text) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('terms', json_build_object(field, ROW(index, type, path, id)::dsl.esqdsl_terms_lookup)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.range(field text, lt text DEFAULT NULL, gt text DEFAULT NULL, lte text DEFAULT NULL, gte text DEFAULT NULL, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('range', json_build_object(field, ROW(lt, gt, lte, gte, boost)::dsl.esqdsl_range_text)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.range(field text, lt numeric DEFAULT NULL, gt numeric DEFAULT NULL, lte numeric DEFAULT NULL, gte numeric DEFAULT NULL, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('range', json_build_object(field, ROW(lt, gt, lte, gte, boost)::dsl.esqdsl_range_text)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.prefix(field text, prefix text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('prefix', json_build_object(field, ROW(prefix, boost)::dsl.esqdsl_prefix)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.wildcard(field text, wildcard text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('wildcard', json_build_object(field, ROW(wildcard, boost)::dsl.esqdsl_wildcard)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.regexp(field text, regexp text, boost real DEFAULT NULL, flags dsl.es_regexp_flags[] DEFAULT NULL, max_determinized_states int DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('regexp', json_build_object(field, ROW(regexp, (SELECT array_to_string(array_agg(DISTINCT flag), '|') FROM unnest(flags) flag), max_determinized_states, boost)::dsl.esqdsl_regexp)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.fuzzy(field text, value text, boost real DEFAULT NULL, fuzziness int DEFAULT NULL, prefix_length int DEFAULT NULL, max_expansions int DEFAULT NULL, transpositions boolean DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('fuzzy', json_build_object(field, ROW(value, boost, fuzziness, prefix_length, max_expansions, transpositions)::dsl.esqdsl_fuzzy)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.match(field text, query text, boost real DEFAULT NULL, analyzer text DEFAULT NULL, minimum_should_match text DEFAULT NULL, lenient boolean DEFAULT NULL, fuzziness int DEFAULT NULL, fuzzy_rewrite text DEFAULT NULL, fuzzy_transpositions boolean DEFAULT NULL, prefix_length int DEFAULT NULL, zero_terms_query dsl.es_match_zero_terms_query DEFAULT NULL, cutoff_frequency real DEFAULT NULL, operator dsl.es_match_operator DEFAULT NULL, auto_generate_synonyms_phrase_query boolean DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('match', json_build_object(field, ROW(query, boost, analyzer, minimum_should_match, lenient, fuzziness, fuzzy_rewrite, fuzzy_transpositions, prefix_length, zero_terms_query, cutoff_frequency, operator, auto_generate_synonyms_phrase_query)::dsl.esqdsl_match)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.match_phrase(field text, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('match_phrase', json_build_object(field, ROW(query, boost, slop, analyzer)::dsl.esqdsl_match_phrase)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.phrase(field text, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT dsl.match_phrase(field, query, boost, slop, analyzer);
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.match_phrase_prefix(field text, query text, boost real DEFAULT NULL, slop int DEFAULT NULL, analyzer text DEFAULT NULL, max_expansions int DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('match_phrase_prefix', json_build_object(field, ROW(query, boost, slop, analyzer, max_expansions)::dsl.esqdsl_match_phrase_prefix)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.common(field text, query text, boost real DEFAULT NULL, cutoff_frequency real DEFAULT NULL, analyzer text DEFAULT NULL, minimum_should_match text DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('common', json_build_object(field, ROW(query, boost, cutoff_frequency, analyzer, minimum_should_match)::dsl.esqdsl_common)))::zdbquery;
+$$;
+
+CREATE TYPE dsl.esqdsl_nested AS (path text, query zdbquery, score_mode dsl.es_nested_score_mode);
+CREATE OR REPLACE FUNCTION dsl.nested(path text, query zdbquery, score_mode dsl.es_nested_score_mode DEFAULT 'avg'::dsl.es_nested_score_mode) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('nested', ROW(path, query, score_mode)::dsl.esqdsl_nested))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.span_term(field text, value text, boost real DEFAULT NULL) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('span_term', json_build_object(field, ROW(value, boost)::dsl.esqdsl_term_text)))::zdbquery;
+$$;
+
+CREATE OR REPLACE FUNCTION dsl.span_masking(field text, query zdbquery) RETURNS zdbquery PARALLEL SAFE IMMUTABLE LANGUAGE sql AS $$
+    SELECT json_strip_nulls(json_build_object('field_masking_span', json_build_object('query', query, 'field', field)))::zdbquery;
+$$;
+
+
+
+

--- a/src/sql/zombodb--10-1.0.1--10-1.0.2.sql
+++ b/src/sql/zombodb--10-1.0.1--10-1.0.2.sql
@@ -25,6 +25,7 @@ DROP FUNCTION dsl.nested;
 DROP FUNCTION dsl.span_term;
 DROP FUNCTION dsl.span_masking;
 DROP TYPE dsl.esqdsl_nested;
+DROP FUNCTION zdb.highlight(tid, name, json);
 
 --
 -- replace functions and types
@@ -145,6 +146,7 @@ CREATE OR REPLACE FUNCTION dsl.span_masking(field text, query zdbquery) RETURNS 
     SELECT json_strip_nulls(json_build_object('field_masking_span', json_build_object('query', query, 'field', field)))::zdbquery;
 $$;
 
+CREATE OR REPLACE FUNCTION highlight(ctid tid, field text, highlight_definition json DEFAULT highlight()) RETURNS text[] PARALLEL UNSAFE STABLE STRICT LANGUAGE c AS 'MODULE_PATHNAME', 'zdb_highlight';
 
 
 

--- a/src/test/expected/test-zdb_ignore_visibility.out
+++ b/src/test/expected/test-zdb_ignore_visibility.out
@@ -1,0 +1,14 @@
+SET zdb.ignore_visibility TO off;
+SELECT count(*) FROM events WHERE events ==> dsl.match_all();
+ count  
+--------
+ 126245
+(1 row)
+
+SET zdb.ignore_visibility TO on;
+SELECT count(*) FROM events WHERE events ==> dsl.match_all();
+ count  
+--------
+ 126245
+(1 row)
+

--- a/src/test/sql/test-zdb_ignore_visibility.sql
+++ b/src/test/sql/test-zdb_ignore_visibility.sql
@@ -1,0 +1,5 @@
+SET zdb.ignore_visibility TO off;
+SELECT count(*) FROM events WHERE events ==> dsl.match_all();
+
+SET zdb.ignore_visibility TO on;
+SELECT count(*) FROM events WHERE events ==> dsl.match_all();

--- a/zombodb.control
+++ b/zombodb.control
@@ -1,6 +1,6 @@
 # ZomboDB extension
 comment = 'ZomboDB:  Making Postgres and Elasticsearch work together like it''s 2018'
-default_version = '10-1.0.1'
+default_version = '10-1.0.2'
 module_pathname = '$libdir/zombodb'
 relocatable = false
 schema = zdb


### PR DESCRIPTION
Prior to this PR, ZomboDB would apply a "visibility query" to every Elasticsearch query executed, including those executed for a normal SELECT statement.

The visibility query is required, in general, to ensure that research results don't include rows which are invisible to the executing transaction.  In the case of SELECT statements, however, Postgres will filter those rows out for us, even if ZDB returns them from Elasticsearch.  This turns out to be significantly faster.

It's still necessary for ZomboDB to apply its "visibility query" for SELECT queries that include a LIMIT clause, and also necessary for all of the Elasticsearch aggregate types that ZomboDB exposes as top-level functions, such as `zdb.terms()`.

Using a very simple pg_bench test, on my laptop, this is how ZDB performed prior to this PR:

```shell
$ cat bench.sql 
select id from events where events ==> dsl.range(field=>'id', lte=>10);

$ pgbench -f ./bench.sql -T 30 -j 5 -c 5 contrib_regression
starting vacuum...end.
transaction type: ./bench.sql
scaling factor: 1
query mode: simple
number of clients: 5
number of threads: 5
duration: 30 s
number of transactions actually processed: 5299
latency average = 28.320 ms
tps = 176.552247 (including connections establishing)
tps = 176.649245 (excluding connections establishing)
```

And this is with this PR applied:

```shell
$ pgbench -f ./bench.sql -T 30 -j 5 -c 5 contrib_regression
starting vacuum...end.
transaction type: ./bench.sql
scaling factor: 1
query mode: simple
number of clients: 5
number of threads: 5
duration: 30 s
number of transactions actually processed: 73216
latency average = 2.051 ms
tps = 2438.259382 (including connections establishing)
tps = 2439.561459 (excluding connections establishing)
```

That's roughly 14x faster, which is quite an improvement!

(As an aside, this PR is based on PR #325)