### PR TITLE
use HTTP/1.1

### DIFF
--- a/src/c/rest/rest.c
+++ b/src/c/rest/rest.c
@@ -199,7 +199,6 @@ void rest_multi_call(MultiRestState *state, char *method, StringInfo url, PostDa
 			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, state->headers[i]);
 			curl_easy_setopt(curl, CURLOPT_POST,
 							 strcmp(method, "GET") != 0 && postData && postData->buff->data ? 1 : 0);
-			curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_0);
 			curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
 
 			curl_multi_add_handle(state->multi_handle, curl);

--- a/src/c/rest/rest.c
+++ b/src/c/rest/rest.c
@@ -168,7 +168,6 @@ void rest_multi_call(MultiRestState *state, char *method, StringInfo url, PostDa
 			curl_easy_setopt(curl, CURLOPT_FAILONERROR, 0);
 			curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 			curl_easy_setopt(curl, CURLOPT_TIMEOUT, 60 * 60L);  /* timeout of 60 minutes */
-			curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
 			curl_easy_setopt(curl, CURLOPT_TCP_KEEPALIVE, 1L);
 			curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errorbuff);
 


### PR DESCRIPTION
Currently, the HTTP version is set to HTTP/1.1 and then later in the same function set to HTTP/1.0.  This PR fixes that so that HTTP/1.1 is used.

I found this one deploying to a k8s cluster with istio, which does not support HTTP/1.0 by default between containers.