### PR TITLE
upgrade from supporting ES v5.6.4 to ES v5.6.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 target/
 .DS_store
 foo.*
-postgres/src/main/sql/zombodb--5.6.4-1.0.17.sql
+postgres/src/main/sql/zombodb--5.6.16-1.0.18.sql
 postgres/src/test/sql/setup.sql
 postgres/src/test/sql/so_comments.sql
 postgres/src/test/sql/TUTORIAL.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_install:
   - sudo apt-get install -y postgresql-9.5 postgresql-server-dev-9.5
   - sudo ls -lad /usr/share/postgresql/*
   - sudo apt-get install -y maven
-  - wget --no-check-certificate https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.4.tar.gz
-  - tar xzf ./elasticsearch-5.6.4.tar.gz
+  - wget --no-check-certificate https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.16.tar.gz
+  - tar xzf ./elasticsearch-5.6.16.tar.gz
 
 script:
   - sudo /etc/init.d/postgresql stop 9.5
@@ -53,8 +53,8 @@ script:
   - sudo rm /usr/lib/postgresql/9.5/lib/zombodb.so
   - sudo src/main/shell/hack-configs-for-travisci.sh
   - cd ${BUILD_HOME}
-  - echo Y | sudo elasticsearch-5.6.4/bin/elasticsearch-plugin install file://${WHERE}/elasticsearch/target/zombodb-es-plugin-${VERSION}.zip
-  - elasticsearch-5.6.4/bin/elasticsearch -d
+  - echo Y | sudo elasticsearch-5.6.16/bin/elasticsearch-plugin install file://${WHERE}/elasticsearch/target/zombodb-es-plugin-${VERSION}.zip
+  - elasticsearch-5.6.16/bin/elasticsearch -d
   - sudo /etc/init.d/postgresql start 9.5
   - sudo cat /var/log/syslog
   - cat /etc/postgresql/9.5/main/postgresql.conf
@@ -69,7 +69,7 @@ script:
 after_failure:
   - sudo cat regression.diffs
   - sudo cat /var/log/postgresql/*.log
-  - sudo cat ${BUILD_HOME}/elasticsearch-5.6.4/logs/*.log | grep -v "deprecated"
+  - sudo cat ${BUILD_HOME}/elasticsearch-5.6.16/logs/*.log | grep -v "deprecated"
   - df -h
   - ps auwwx
   - sudo dmesg

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@
 
 ZomboDB consists of two pieces.  One is a Postgres Extension (written in C and SQL/PLPGSQL), and the other is an Elasticsearch plugin (written in Java).
 
-Currently ZomboDB supports Postgres `v9.3`, `v9.4`, or `v9.5` (on x86_64 Linux) and Elasticsearch `v5.6.4`.
+Currently ZomboDB supports Postgres `v9.3`, `v9.4`, or `v9.5` (on x86_64 Linux) and Elasticsearch `v5.6.16`.
 
 
 ## Postgres Extension

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # [![ZomboDB](logo.png)](http://www.zombodb.com/) [![Build Status](https://travis-ci.org/zombodb/zombodb.svg?branch=master)](https://travis-ci.org/zombodb/zombodb/branches)
 
-(This branch is for Elasticsearch 5.6.4)
+(This branch is for Elasticsearch 5.6.16)
 
 ## Upgrading from ES 1.7 or ES 2.4?
 
-In short, ZomboDB doesn't provide a migration process from ES 1.7/2.4 to ES 5.6.4.  You'll need to drop all of your `USING zombodb` indexes, manually delete all the indexes from your ES cluster, upgrade your ES cluster to 5.6.4, upgrade the ZomboDB Postgres extension to v5.6.4-x.x.x and then re-create all your `USING zombodb` indexes.
+In short, ZomboDB doesn't provide a migration process from ES 1.7/2.4 to ES 5.6.16.  You'll need to drop all of your `USING zombodb` indexes, manually delete all the indexes from your ES cluster, upgrade your ES cluster to 5.6.16, upgrade the ZomboDB Postgres extension to v5.6.16-x.x.x and then re-create all your `USING zombodb` indexes.
 
 If you require assistance with this process, please don't hesitate to [contact ZomboDB, LLC](https://www.zombodb.com/services/).
 
-## What's Different with ES 5.6.4+ Support?
+## What's Different with ES 5.6.16+ Support?
 
 In general, everything is significantly faster.  
 
-Elasticsearch 5.6.4 is generally faster for indexing and searching, and its API has improved such that ZomboDB is able to implement certain optimizations that make everything faster.
+Elasticsearch 5.6.16 is generally faster for indexing and searching, and its API has improved such that ZomboDB is able to implement certain optimizations that make everything faster.
 
 All SQL-level syntax is backwards-compatible along with ZomboDB's query language syntax.
 
@@ -40,7 +40,7 @@ Elasticsearch-calculated aggregations are also provided through custom functions
    - [Index Management](INDEX-MANAGEMENT.md), [Index Options](INDEX-OPTIONS.md), and [Type Mapping](TYPE-MAPPING.md)
    - [Query Syntax](SYNTAX.md)  
    - [SQL-level API](SQL-API.md)  
-   - [v5.6.4-1.0.0 Release Notes](https://github.com/zombodb/zombodb/releases/tag/v5.6.4-1.0.0_beta1)
+   - [v5.6.16-1.0.0 Release Notes](https://github.com/zombodb/zombodb/releases/tag/v5.6.16-1.0.0_beta1)
 
 ## Features
 
@@ -99,7 +99,7 @@ For the Postgres extension binaries, you'll need to use the one that's for your 
 Product       | Version 
 ---           | ---      
 Postgres      | 9.3, 9.4, 9.5
-Elasticsearch | 5.6.4
+Elasticsearch | 5.6.16
 
 For information about how to develop/build ZomboDB, see the [Development Guide](DEVELOPER.md).
 

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -8,8 +8,8 @@
 # Pull base image.
 FROM java:8
 
-ENV ES_PKG_NAME elasticsearch-5.6.4
-ENV ZOMBODB_VER 5.6.4-1.0.17
+ENV ES_PKG_NAME elasticsearch-5.6.16
+ENV ZOMBODB_VER 5.6.16-1.0.18
 
 # need a non-root user to run elasticsearch
 RUN useradd -ms /bin/bash elastic

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -4,7 +4,7 @@
 
 # Pull base image.
 FROM postgres:9.5
-ENV ZOMBODB_VER 5.6.4-1.0.17
+ENV ZOMBODB_VER 5.6.16-1.0.18
 
 # Fetch wget
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/*

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>llc.elasticsearch</groupId>
         <artifactId>zombodb-parent</artifactId>
-        <version>5.6.4-1.0.17</version>
+        <version>5.6.16-1.0.18</version>
     </parent>
 
     <artifactId>zombodb-plugin</artifactId>
@@ -63,13 +63,13 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>5.6.4</version>
+            <version>5.6.16</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
-            <version>5.6.4</version>
+            <version>5.6.16</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/elasticsearch/src/main/assemblies/plugin.xml
+++ b/elasticsearch/src/main/assemblies/plugin.xml
@@ -22,6 +22,12 @@
             <outputDirectory>/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+                <exclude>org.elasticsearch:jna</exclude>
+                <exclude>com.vividsolutions:jts</exclude>
+                <exclude>org.locationtech.spatial4j:spatial4j</exclude>
+                <exclude>log4j:log4j</exclude>
+            </excludes>
         </dependencySet>
     </dependencySets>
 </assembly>

--- a/elasticsearch/src/main/resources/plugin-descriptor.properties
+++ b/elasticsearch/src/main/resources/plugin-descriptor.properties
@@ -1,7 +1,7 @@
 description=Making Postgres and Elasticsearch work together like it is 2019
-version=5.6.4-1.0.17
+version=5.6.16-1.0.18
 name=zombodb
 jvm=true
 classname=llc.zombodb.ZomboDBPlugin
 java.version=1.7
-elasticsearch.version=5.6.4
+elasticsearch.version=5.6.16

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>llc.elasticsearch</groupId>
     <artifactId>zombodb-parent</artifactId>
-    <version>5.6.4-1.0.17</version>
+    <version>5.6.16-1.0.18</version>
 
     <packaging>pom</packaging>
 

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>llc.elasticsearch</groupId>
         <artifactId>zombodb-parent</artifactId>
-        <version>5.6.4-1.0.17</version>
+        <version>5.6.16-1.0.18</version>
     </parent>
 
     <artifactId>zombodb</artifactId>

--- a/postgres/src/main/shell/hack-configs-for-travisci.sh
+++ b/postgres/src/main/shell/hack-configs-for-travisci.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-cat << DONE >> ~/elasticsearch-5.6.4/config/elasticsearch.yml
+cat << DONE >> ~/elasticsearch-5.6.16/config/elasticsearch.yml
 http.max_content_length: 1024mb
 index.query.bool.max_clause_count: 1000000
 DONE

--- a/postgres/src/main/sql/zombodb--5.6.4-1.0.17--5.6.16-1.0.18.sql
+++ b/postgres/src/main/sql/zombodb--5.6.4-1.0.17--5.6.16-1.0.18.sql
@@ -1,0 +1,1 @@
+-- no sql changes

--- a/postgres/zombodb.control
+++ b/postgres/zombodb.control
@@ -1,6 +1,6 @@
 # zombodb extension
 comment = 'Elasticsearch-enabled Index Type for Postgres'
-default_version = '5.6.4-1.0.17'
+default_version = '5.6.16-1.0.18'
 module_pathname = '$libdir/zombodb'
 relocatable = true
 requires = ''


### PR DESCRIPTION
This PR changes ZDB's ES 5.6 support branches from 5.6.4 to 5.6.16.

This change is necessary to that ZDB users won't be affected by this ES bug:  https://github.com/elastic/elasticsearch/pull/36770, which apparently is fairly easy for ZDB to trigger b/c of its concurrent indexing requests