### PR TITLE
fix compilation warning because panic! first argument should be a string literal

### DIFF
--- a/src/access_method/options.rs
+++ b/src/access_method/options.rs
@@ -570,7 +570,7 @@ extern "C" fn validate_url(url: *const std::os::raw::c_char) {
     }
 
     if let Err(e) = url::Url::parse(url) {
-        panic!(e.to_string())
+        panic!("{}", e.to_string())
     }
 }
 

--- a/src/executor_manager/mod.rs
+++ b/src/executor_manager/mod.rs
@@ -282,7 +282,7 @@ impl ExecutorManager {
                 let tupdesc = bulk.tupdesc;
 
                 if let Err(e) = bulk.bulk.finish() {
-                    panic!(e)
+                    panic!("{}", e)
                 }
 
                 let bulk = elasticsearch.start_bulk();


### PR DESCRIPTION
fix those two warnings:

> warning: panic message is not a string literal
   --> src/access_method/options.rs:573:16
    |
573 |         panic!(e.to_string())
    |                ^^^^^^^^^^^^^
    |
    = note: `#[warn(non_fmt_panic)]` on by default
    = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
    |
573 |         panic!("{}", e.to_string())
    |                ^^^^^
help: or use std::panic::panic_any instead
    |
573 |         std::panic::panic_any(e.to_string())
    |         ^^^^^^^^^^^^^^^^^^^^^^

> warning: panic message is not a string literal
   --> src/executor_manager/mod.rs:285:28
    |
285 |                     panic!(e)
    |                            ^
    |
    = note: this is no longer accepted in Rust 2021
help: add a "{}" format string to Display the message
    |
285 |                     panic!("{}", e)
    |                            ^^^^^
help: or use std::panic::panic_any instead
    |
285 |                     std::panic::panic_any(e)
    |                     ^^^^^^^^^^^^^^^^^^^^^^