### PR TITLE
fix json-escape with non-ascii character

### DIFF
--- a/INDEX-MANAGEMENT.md
+++ b/INDEX-MANAGEMENT.md
@@ -201,13 +201,13 @@ Sets the HTTP(s) transport (and request body) deflate compression level.  Over s
 
 ### Nested Object Mapping Options
 
-#### `nesed_object_date_detection`
+#### `nested_object_date_detection`
 ```
 Type: bool
 Default: false
 ```
 
-If `nesed_object_date_detection` is enabled (default is false), then new string fields 
+If `nested_object_date_detection` is enabled (default is false), then new string fields 
 in nested objects (fields of type 'json' or 'jsonb') are checked to see whether their 
 contents match any of the date patterns specified in dynamic_date_formats. If a match is 
 found, a new date field is added with the corresponding format.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ZomboDB allows you to use the power and scalability of Elasticsearch directly fr
  - [Query DSL](QUERY-DSL.md)
  - [Aggregations](AGGREGATIONS.md), [Scoring and Highlighting](SCORING-HIGHLIGHTING.md)
  - [SQL Functions](SQL-FUNCTIONS.md)
- - [Configuration Settings](CONFIGURATION-SETTINGS.md), [Index Managment](INDEX-MANAGEMENT.md)
+ - [Configuration Settings](CONFIGURATION-SETTINGS.md), [Index Management](INDEX-MANAGEMENT.md)
  - [Type Mapping](TYPE-MAPPING.md)
  - [Elasticsearch _cat API](CAT-API.md)
  - [VACUUM Support](VACUUM.md)


### PR DESCRIPTION
Fix json-escape bug with non-ascii character, which corrupts text field while pushing document into Elasticsearch.
