### PR TITLE
replaces drain(0..).collect() with take()

### DIFF
--- a/INDEX-MANAGEMENT.md
+++ b/INDEX-MANAGEMENT.md
@@ -201,13 +201,13 @@ Sets the HTTP(s) transport (and request body) deflate compression level.  Over s
 
 ### Nested Object Mapping Options
 
-#### `nesed_object_date_detection`
+#### `nested_object_date_detection`
 ```
 Type: bool
 Default: false
 ```
 
-If `nesed_object_date_detection` is enabled (default is false), then new string fields 
+If `nested_object_date_detection` is enabled (default is false), then new string fields 
 in nested objects (fields of type 'json' or 'jsonb') are checked to see whether their 
 contents match any of the date patterns specified in dynamic_date_formats. If a match is 
 found, a new date field is added with the corresponding format.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ ZomboDB allows you to use the power and scalability of Elasticsearch directly fr
  - [Query DSL](QUERY-DSL.md)
  - [Aggregations](AGGREGATIONS.md), [Scoring and Highlighting](SCORING-HIGHLIGHTING.md)
  - [SQL Functions](SQL-FUNCTIONS.md)
- - [Configuration Settings](CONFIGURATION-SETTINGS.md), [Index Managment](INDEX-MANAGEMENT.md)
+ - [Configuration Settings](CONFIGURATION-SETTINGS.md), [Index Management](INDEX-MANAGEMENT.md)
  - [Type Mapping](TYPE-MAPPING.md)
  - [Elasticsearch _cat API](CAT-API.md)
  - [VACUUM Support](VACUUM.md)

--- a/src/elasticsearch/bulk.rs
+++ b/src/elasticsearch/bulk.rs
@@ -114,7 +114,7 @@ impl ElasticsearchBulkRequest {
         self.handler.check_for_error();
 
         // do we have any deferred commands we need to process again?
-        let deferred_commands: Vec<BulkRequestCommand> = self.handler.deferred.drain(0..).collect();
+        let deferred_commands = std::mem::take(&mut self.handler.deferred);
         let mut deferred_request = None;
         if !deferred_commands.is_empty() {
             deferred_request = Some(self.clone());


### PR DESCRIPTION
I discovered the `drain(0..).collect()` while tracking down #647, which could be replaced with `std::mem::take` https://doc.rust-lang.org/stable/std/mem/fn.take.html
It's just a minor nitpick, so feel free to merge or close :)