### PR TITLE
Fixed system requirements table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ These limitations may be addressed in future versions of ZomboDB.
 
 ## System Requirements
 
-Product | Version --- | ---\
-Postgres | 10.x, 11.x, 12.x, 13.x Elasticsearch | 7.x
+| Product       | Version                |
+| ------------- | ---------------------- |
+| Postgres      | 10.x, 11.x, 12.x, 13.x |
+| Elasticsearch | 7.x                    |
 
 ## Sponsorship and Downloads
 


### PR DESCRIPTION
The render of the markdown table on GitHub is also fixed by this tiny patch.
## Before
<img width="407" alt="image" src="https://user-images.githubusercontent.com/1266923/142935463-9a4221e8-62d8-4a86-b003-d51b50524108.png">

## After
<img width="361" alt="image" src="https://user-images.githubusercontent.com/1266923/142935611-c653a0f6-8e7d-402d-849a-223dcf42e6ef.png">
