### PR TITLE
implement single-arg `zdb.highlight()` to fetch all highlights

### DIFF
--- a/src/executor_manager/mod.rs
+++ b/src/executor_manager/mod.rs
@@ -93,6 +93,14 @@ impl QueryState {
         }
     }
 
+    pub fn get_highlights(
+        &self,
+        heap_oid: pg_sys::Oid,
+        ctid: pg_sys::ItemPointerData,
+    ) -> Option<&HashMap<String, Vec<String>>> {
+        self.highlights.get(&(heap_oid, item_pointer_get_both(ctid)))
+    }
+
     pub fn get_highlight(
         &self,
         heap_oid: pg_sys::Oid,

--- a/src/walker/mod.rs
+++ b/src/walker/mod.rs
@@ -5,6 +5,7 @@ pub struct PlanWalker {
     zdbquery_oid: pg_sys::Oid,
     zdb_score_oid: pg_sys::Oid,
     zdb_highlight_oid: pg_sys::Oid,
+    zdb_highlight_all_fields_oid: pg_sys::Oid,
     zdb_anyelement_cmp_func_oid: pg_sys::Oid,
     zdb_want_score_oid: pg_sys::Oid,
     zdb_want_highlight_oid: pg_sys::Oid,
@@ -34,6 +35,10 @@ impl PlanWalker {
                 Some(vec![pg_sys::TIDOID, pg_sys::TEXTOID, pg_sys::JSONOID]),
             )
             .unwrap_or(pg_sys::InvalidOid),
+            zdb_highlight_all_fields_oid: lookup_function(
+                vec!["zdb", "highlight"],
+                Some(vec![pg_sys::TIDOID, pg_sys::JSONOID]),
+            ).unwrap_or(pg_sys::InvalidOid),
             zdb_anyelement_cmp_func_oid: lookup_function(
                 vec!["zdb", "anyelement_cmpfunc"],
                 Some(vec![pg_sys::ANYELEMENTOID, zdbquery_oid]),
@@ -126,7 +131,7 @@ unsafe extern "C" fn plan_walker(node: *mut pg_sys::Node, context_ptr: void_mut_
             } else {
                 panic!("zdb.score() can only be used as a target entry or as a sort");
             }
-        } else if func_expr.funcid == context.zdb_highlight_oid {
+        } else if func_expr.funcid == context.zdb_highlight_oid || func_expr.funcid == context.zdb_highlight_all_fields_oid {
             // if context.in_te > 0 {
             context.highlight_definitions.push(func_expr.as_ptr());
             // } else {
@@ -196,17 +201,25 @@ unsafe extern "C" fn rewrite_walker(node: *mut pg_sys::Node, context_ptr: void_m
 
                             let definition = PgBox::from_pg(*definition);
                             let definition_args = PgList::from_pg(definition.args);
+                            let highlight_all_fields = definition.funcid == context.zdb_highlight_all_fields_oid;
 
                             func_args.push(
-                                definition_args
-                                    .get_ptr(1)
-                                    .expect("no field name for zdb.highlight()")
-                                    as *mut pg_sys::Node,
+                                if highlight_all_fields {
+                                    let mut asteriskConstNode = PgBox::<pg_sys::Const>::alloc_node(pg_sys::NodeTag_T_Const);
+
+                                    asteriskConstNode.consttype = pg_sys::TEXTOID;
+                                    asteriskConstNode.constlen = 1;
+                                    asteriskConstNode.constvalue = pgx::rust_str_to_text_p("*").as_ptr() as pg_sys::Datum;
+
+                                    asteriskConstNode.into_pg() as *mut pg_sys::Node
+                                } else {
+                                    definition_args.get_ptr(1).expect("no field name for zdb.highlight()")
+                                }
                             );
 
                             // if we have a highlight definition we'll use it, if not, that's
                             // okay too as "want_highlight()" has a default for that argument
-                            if let Some(definition_json) = definition_args.get_ptr(2) {
+                            if let Some(definition_json) = definition_args.get_ptr(if highlight_all_fields { 1 } else { 2 }) {
                                 func_args.push(definition_json as *mut pg_sys::Node);
                             }
 


### PR DESCRIPTION
This is a PoC for #773 that implements `zdb.highlight(ctid)`, which fetches all highlights regardless of field name.

(Please note that I'm no expert in any of Elasticsearch, PGX or Rust and it's been a while since I last dabbled in PG internals.)

Another API design issue to be aware of, is that to pass highlight options, one has to explicitly cast the optional second argument to JSON:

```sql
-- Assumes the second argument is the field name, calls highlight_field(), does not work correctly.
SELECT zdb.highlight(ctid, '{...}') FROM table;

-- Calls highlight_all_fields(), works correctly.
SELECT zdb.highlight(ctid, '{...}'::json) FROM table;
```