### PR TITLE
Update System Requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ These limitations may be addressed in future versions of ZomboDB.
 
 ## System Requirements
 
-| Product       | Version                |
-| ------------- | ---------------------- |
-| Postgres      | 10.x, 11.x, 12.x, 13.x |
-| Elasticsearch | 7.x                    |
+| Product       | Version                      |
+| ------------- | ---------------------------- |
+| Postgres      | 10.x, 11.x, 12.x, 13.x, 14.x |
+| Elasticsearch | >=7.10                       |
 
 ## Sponsorship and Downloads
 


### PR DESCRIPTION
- Added Postgres `14.x`
- Require Elasticsearch to be `>=7.10` as `case_insensitive` for prefix queries was not supported below that, which ZDB requires since (at least) 852bd35ee113718dcc9ab9b5d6d56f4ad7a1ed9a