### PR TITLE
fix issue #770

### DIFF
--- a/SQL-FUNCTIONS.md
+++ b/SQL-FUNCTIONS.md
@@ -181,6 +181,19 @@ SELECT * FROM zdb_get_index_field_lists('idxsome_index');
 ______________________________________________________________________
 
 ```sql
+FUNCTION zdb.reapply_mapping(index regclass) RETURNS bool
+```
+
+If you make a manual change to one of the underlying type mapping definitions (or related analyzer definition)
+in, for example, the `zdb.type_mappings` table, you can use this function to push those changes out to Elasticsearch
+for a specific index.
+
+If for some reason the overall mapping change is not compatible with the index's existing mapping you'll need
+to instead issue a `REINDEX INDEX` command.
+
+______________________________________________________________________
+
+```sql
 FUNCTION zdb.index_mapping(index regclass) RETURNS jsonb
 ```
 

--- a/sql/_mappings.sql
+++ b/sql/_mappings.sql
@@ -379,7 +379,7 @@ VALUES ('time without time zone', '{
   "fields": {
     "date": {
       "type": "date",
-      "format": "HH:mm:ss.S||HH:mm:ss.SS||HH:mm:ss.SSS||HH:mm:ss.SSSS||HH:mm:ss.SSSSS||HH:mm:ss.SSSSSS"
+      "format": "HH:mm||HH:mm:ss||HH:mm:ss.S||HH:mm:ss.SS||HH:mm:ss.SSS||HH:mm:ss.SSSS||HH:mm:ss.SSSSS||HH:mm:ss.SSSSSS"
     }
   }
 }', true) ON CONFLICT (type_name) DO UPDATE SET definition = excluded.definition;
@@ -391,7 +391,7 @@ VALUES ('time with time zone', '{
   "fields": {
     "date": {
       "type": "date",
-      "format": "HH:mm:ss.SX||HH:mm:ss.SSX||HH:mm:ss.SSSX||HH:mm:ss.SSSSX||HH:mm:ss.SSSSSX||HH:mm:ss.SSSSSSX"
+      "format": "HH:mmX||HH:mm:ssX||HH:mm:ss.SX||HH:mm:ss.SSX||HH:mm:ss.SSSX||HH:mm:ss.SSSSX||HH:mm:ss.SSSSSX||HH:mm:ss.SSSSSSX"
     }
   }
 }

--- a/test/expected/issue-770.out
+++ b/test/expected/issue-770.out
@@ -1,0 +1,36 @@
+CREATE TABLE issue770_without (
+    ts time without time zone
+);
+CREATE INDEX idxissue770 ON issue770_without USING zombodb ((issue770_without.*));
+INSERT INTO issue770_without (ts) VALUES ('15:00');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.0');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.00');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.0000');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.00000');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.000000');
+SELECT zdb.reapply_mapping('issue770_without');
+ reapply_mapping 
+-----------------
+ t
+(1 row)
+
+DROP TABLE issue770_without;
+CREATE TABLE issue770_with (
+    ts time with time zone
+);
+CREATE INDEX idxissue770 ON issue770_with USING zombodb ((issue770_with.*));
+INSERT INTO issue770_with (ts) VALUES ('15:00');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.0');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.00');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.0000');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.00000');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.000000');
+SELECT zdb.reapply_mapping('issue770_with');
+ reapply_mapping 
+-----------------
+ t
+(1 row)
+
+DROP TABLE issue770_with;

--- a/test/sql/issue-770.sql
+++ b/test/sql/issue-770.sql
@@ -1,0 +1,32 @@
+CREATE TABLE issue770_without (
+    ts time without time zone
+);
+CREATE INDEX idxissue770 ON issue770_without USING zombodb ((issue770_without.*));
+
+INSERT INTO issue770_without (ts) VALUES ('15:00');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.0');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.00');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.0000');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.00000');
+INSERT INTO issue770_without (ts) VALUES ('15:00:00.000000');
+
+SELECT zdb.reapply_mapping('issue770_without');
+DROP TABLE issue770_without;
+
+CREATE TABLE issue770_with (
+    ts time with time zone
+);
+CREATE INDEX idxissue770 ON issue770_with USING zombodb ((issue770_with.*));
+
+INSERT INTO issue770_with (ts) VALUES ('15:00');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.0');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.00');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.0000');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.00000');
+INSERT INTO issue770_with (ts) VALUES ('15:00:00.000000');
+SELECT zdb.reapply_mapping('issue770_with');
+
+DROP TABLE issue770_with;
+


### PR DESCRIPTION
This adds a few more allowed time formats for the `time with(out) time zone` types.

It also adds a new function named `zdb.reapply_mapping(regclass)` that can be used to reapply the index mapping when a "mapping thing" changes, such as a row in the `zdb.type_mappings` table.