### PR TITLE
"fix" issue #812 by not highlighting tokens of type "shingle"...

### DIFF
--- a/src/highlighting/query_highlighter.rs
+++ b/src/highlighting/query_highlighter.rs
@@ -43,7 +43,7 @@ impl QueryHighlighter {
             }
         });
 
-        let mut highlights = HashMap::new();
+        let mut highlights = Default::default();
         let result: Box<
             dyn std::iter::Iterator<
                 Item = (
@@ -87,7 +87,7 @@ impl QueryHighlighter {
 
     fn walk_expression<'a>(
         expr: &Expr<'a>,
-        highlights: &mut HashMap<(QualifiedField, String), HighlightMatches<'a>>,
+        highlights: &mut HighlightCollection<'a>,
         highlighters: &'a HashMap<String, Vec<DocumentHighlighter<'a>>>,
     ) -> bool {
         match expr {
@@ -99,7 +99,7 @@ impl QueryHighlighter {
 
             Expr::AndList(v) => {
                 let mut did_highlight = false;
-                let mut tmp_highlights = HashMap::new();
+                let mut tmp_highlights = Default::default();
 
                 for e in v {
                     did_highlight =
@@ -118,11 +118,11 @@ impl QueryHighlighter {
 
             Expr::WithList(v) => {
                 let mut did_highlight = false;
-                let mut tmp_highlights = HashMap::new();
+                let mut tmp_highlights = HighlightCollection::default();
                 let mut array_indexes = HashSet::new();
 
                 for e in v {
-                    let mut matches = HashMap::new();
+                    let mut matches = HighlightCollection::default();
                     did_highlight =
                         QueryHighlighter::walk_expression(e, &mut matches, highlighters);
                     if !did_highlight {
@@ -176,7 +176,7 @@ impl QueryHighlighter {
                 let mut did_highlight = false;
 
                 for e in v {
-                    let mut tmp_highlights = HashMap::new();
+                    let mut tmp_highlights = HighlightCollection::default();
                     if QueryHighlighter::walk_expression(e, &mut tmp_highlights, highlighters) {
                         highlights.extend(tmp_highlights);
                         did_highlight = true;
@@ -322,7 +322,7 @@ impl QueryHighlighter {
         field: QualifiedField,
         expr: &Expr<'a>,
         term: &Term,
-        highlights: &mut HashMap<(QualifiedField, String), HighlightMatches<'a>>,
+        highlights: &mut HighlightCollection<'a>,
         eval: F,
     ) -> bool {
         let mut cnt = 0;
@@ -345,7 +345,7 @@ impl QueryHighlighter {
         field: QualifiedField,
         expr: &Expr<'a>,
         term: &Term,
-        highlights: &mut HashMap<(QualifiedField, String), HighlightMatches<'a>>,
+        highlights: &mut HighlightCollection<'a>,
     ) -> bool {
         let mut cnt = 0;
         match term {
@@ -431,7 +431,7 @@ impl QueryHighlighter {
         expr: &Expr<'a>,
         field: &QualifiedField,
         mut entries: HighlightMatches<'a>,
-        highlights: &mut HashMap<(QualifiedField, String), HighlightMatches<'a>>,
+        highlights: &mut HighlightCollection<'a>,
     ) {
         highlights
             // for this field in our map of highlights

--- a/src/zql/ast.rs
+++ b/src/zql/ast.rs
@@ -68,7 +68,7 @@ pub struct QualifiedIndex {
     pub index: String,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct QualifiedField {
     pub index: Option<IndexLink>,
     pub field: String,

--- a/test/expected/issue-812.out
+++ b/test/expected/issue-812.out
@@ -1,0 +1,31 @@
+create schema wi60341;
+create table wi60341.hili_recreate (
+                                       pk_data_id serial8,
+                                       data_full_text zdb.fulltext_with_shingles,
+                                       constraint idx_wi60341_hili_recreate_pkey primary key (pk_data_id));
+create index es_wi60341_hili_recreate on wi60341.hili_recreate using zombodb ((wi60341.hili_recreate.*)) with (shards='5', replicas='1', max_analyze_token_count='10000000', max_terms_count='2147483647');
+insert into wi60341.hili_recreate (pk_data_id, data_full_text) values (1, E'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n');
+-- first query
+select highlights.*
+from (
+         select *
+         from wi60341.hili_recreate
+         where pk_data_id = 1
+     ) crv
+         inner join lateral
+    zdb.highlight_document('wi60341.hili_recreate'::regclass,to_json(crv),
+                           'data_full_text:("Duis*" W/3 "aute*")'::text) as highlights ON true
+order by position, start_offset, end_offset, term;
+   field_name   | array_index | term |    type    | position | start_offset | end_offset |             query_clause             
+----------------+-------------+------+------------+----------+--------------+------------+--------------------------------------
+ data_full_text |           0 | duis | <ALPHANUM> |       37 |          232 |        236 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |       38 |          237 |        241 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | duis | <ALPHANUM> |      106 |          678 |        682 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |      107 |          683 |        687 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | duis | <ALPHANUM> |      175 |         1124 |       1128 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |      176 |         1129 |       1133 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | duis | <ALPHANUM> |      244 |         1570 |       1574 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |      245 |         1575 |       1579 | data_full_text:("duis*" W/3 "aute*")
+(8 rows)
+
+drop schema wi60341 cascade;

--- a/test/sql/issue-812.sql
+++ b/test/sql/issue-812.sql
@@ -1,0 +1,25 @@
+create schema wi60341;
+
+create table wi60341.hili_recreate (
+                                       pk_data_id serial8,
+                                       data_full_text zdb.fulltext_with_shingles,
+                                       constraint idx_wi60341_hili_recreate_pkey primary key (pk_data_id));
+
+create index es_wi60341_hili_recreate on wi60341.hili_recreate using zombodb ((wi60341.hili_recreate.*)) with (shards='5', replicas='1', max_analyze_token_count='10000000', max_terms_count='2147483647');
+
+
+insert into wi60341.hili_recreate (pk_data_id, data_full_text) values (1, E'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n');
+
+-- first query
+select highlights.*
+from (
+         select *
+         from wi60341.hili_recreate
+         where pk_data_id = 1
+     ) crv
+         inner join lateral
+    zdb.highlight_document('wi60341.hili_recreate'::regclass,to_json(crv),
+                           'data_full_text:("Duis*" W/3 "aute*")'::text) as highlights ON true
+order by position, start_offset, end_offset, term;
+
+drop schema wi60341 cascade;


### PR DESCRIPTION
...when highlighting a field with the type `fulltext_with_shingles`.

ZDB's highlighter isn't smart enough to handle highlighting documents that might have multiple terms at the same position, which is effectively what `fulltext_with_shingles` emits.