### PR TITLE
fix issue #822 - searching with a wildcard at the end of a date

### DIFF
--- a/src/zql/transformations/prox_rewriter.rs
+++ b/src/zql/transformations/prox_rewriter.rs
@@ -56,7 +56,7 @@ fn rewrite_term(field: &QualifiedField, term: &mut Term) {
                     Ok::<_, &str>(lookup_es_field_type(&index, &field.field_name()))
                 })
                 .unwrap_or_else(|| Ok("zdb_standard".to_string()))
-                .expect("unable to lookup field analyzer");
+                .unwrap_or_else(|_| "zdb_standard".to_string()); // we could panic here instead, but some of the test suite doesn't have access to the database, so just assume something
 
             if field_type != "keyword" && s.unicode_words().count() > 1 {
                 match ProximityTerm::make_proximity_chain(field, s, *b) {

--- a/src/zql/transformations/prox_rewriter.rs
+++ b/src/zql/transformations/prox_rewriter.rs
@@ -1,3 +1,4 @@
+use crate::utils::lookup_es_field_type;
 use crate::zql::ast::{Expr, ProximityTerm, QualifiedField, Term};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -47,7 +48,17 @@ fn rewrite_term(field: &QualifiedField, term: &mut Term) {
             }
         }
         Term::Prefix(s, b) => {
-            if s.unicode_words().count() > 1 {
+            let field_type = field
+                .index
+                .as_ref()
+                .map(|index_link| {
+                    let index = index_link.open_index()?;
+                    Ok::<_, &str>(lookup_es_field_type(&index, &field.field_name()))
+                })
+                .unwrap_or_else(|| Ok("zdb_standard".to_string()))
+                .expect("unable to lookup field analyzer");
+
+            if field_type != "keyword" && s.unicode_words().count() > 1 {
                 match ProximityTerm::make_proximity_chain(field, s, *b) {
                     ProximityTerm::ProximityChain(chain) => {
                         *term = Term::ProximityChain(chain);

--- a/test/expected/issue-822.out
+++ b/test/expected/issue-822.out
@@ -1,0 +1,137 @@
+CREATE TABLE issue822 (
+                                      id SERIAL8 NOT NULL PRIMARY KEY,
+                                      name text NOT NULL,
+                                      testdate date
+);
+CREATE INDEX es_idxwildcardeddatetest
+    ON issue822 USING zombodb ((issue822.*));
+INSERT INTO issue822(name, testdate)
+SELECT 'testrow'||x, '2022-12-01'::date + (x||' days')::interval FROM generate_series(1, 1000) x;
+-- should be a prefix query
+select * from zdb.dump_query('issue822', '( testdate  = "2022-12-*" )');
+             dump_query             
+------------------------------------
+ {                                 +
+   "prefix": {                     +
+     "testdate": {                 +
+       "value": "2022-12-",        +
+       "case_insensitive": true,   +
+       "rewrite": "constant_score",+
+       "boost": 1.0                +
+     }                             +
+   }                               +
+ }
+(1 row)
+
+SELECT * FROM issue822 WHERE issue822 ==> '( testdate  = "2022-12-*" )' order by id;
+ id |   name    |  testdate  
+----+-----------+------------
+  1 | testrow1  | 12-02-2022
+  2 | testrow2  | 12-03-2022
+  3 | testrow3  | 12-04-2022
+  4 | testrow4  | 12-05-2022
+  5 | testrow5  | 12-06-2022
+  6 | testrow6  | 12-07-2022
+  7 | testrow7  | 12-08-2022
+  8 | testrow8  | 12-09-2022
+  9 | testrow9  | 12-10-2022
+ 10 | testrow10 | 12-11-2022
+ 11 | testrow11 | 12-12-2022
+ 12 | testrow12 | 12-13-2022
+ 13 | testrow13 | 12-14-2022
+ 14 | testrow14 | 12-15-2022
+ 15 | testrow15 | 12-16-2022
+ 16 | testrow16 | 12-17-2022
+ 17 | testrow17 | 12-18-2022
+ 18 | testrow18 | 12-19-2022
+ 19 | testrow19 | 12-20-2022
+ 20 | testrow20 | 12-21-2022
+ 21 | testrow21 | 12-22-2022
+ 22 | testrow22 | 12-23-2022
+ 23 | testrow23 | 12-24-2022
+ 24 | testrow24 | 12-25-2022
+ 25 | testrow25 | 12-26-2022
+ 26 | testrow26 | 12-27-2022
+ 27 | testrow27 | 12-28-2022
+ 28 | testrow28 | 12-29-2022
+ 29 | testrow29 | 12-30-2022
+ 30 | testrow30 | 12-31-2022
+(30 rows)
+
+SELECT * FROM issue822 WHERE issue822 ==> '( testdate  = "2022-12*" )' order by id;
+ id |   name    |  testdate  
+----+-----------+------------
+  1 | testrow1  | 12-02-2022
+  2 | testrow2  | 12-03-2022
+  3 | testrow3  | 12-04-2022
+  4 | testrow4  | 12-05-2022
+  5 | testrow5  | 12-06-2022
+  6 | testrow6  | 12-07-2022
+  7 | testrow7  | 12-08-2022
+  8 | testrow8  | 12-09-2022
+  9 | testrow9  | 12-10-2022
+ 10 | testrow10 | 12-11-2022
+ 11 | testrow11 | 12-12-2022
+ 12 | testrow12 | 12-13-2022
+ 13 | testrow13 | 12-14-2022
+ 14 | testrow14 | 12-15-2022
+ 15 | testrow15 | 12-16-2022
+ 16 | testrow16 | 12-17-2022
+ 17 | testrow17 | 12-18-2022
+ 18 | testrow18 | 12-19-2022
+ 19 | testrow19 | 12-20-2022
+ 20 | testrow20 | 12-21-2022
+ 21 | testrow21 | 12-22-2022
+ 22 | testrow22 | 12-23-2022
+ 23 | testrow23 | 12-24-2022
+ 24 | testrow24 | 12-25-2022
+ 25 | testrow25 | 12-26-2022
+ 26 | testrow26 | 12-27-2022
+ 27 | testrow27 | 12-28-2022
+ 28 | testrow28 | 12-29-2022
+ 29 | testrow29 | 12-30-2022
+ 30 | testrow30 | 12-31-2022
+(30 rows)
+
+SELECT upper(term) term, count
+FROM zdb.tally('issue822'::regclass,
+               'name',
+               'FALSE',
+               '^.*',
+               '( testdate  = "2022-12*" )'::zdbquery, 2147483647,
+               'count'::termsorderby) order by 1, 2;
+   term    | count 
+-----------+-------
+ TESTROW1  |     1
+ TESTROW10 |     1
+ TESTROW11 |     1
+ TESTROW12 |     1
+ TESTROW13 |     1
+ TESTROW14 |     1
+ TESTROW15 |     1
+ TESTROW16 |     1
+ TESTROW17 |     1
+ TESTROW18 |     1
+ TESTROW19 |     1
+ TESTROW2  |     1
+ TESTROW20 |     1
+ TESTROW21 |     1
+ TESTROW22 |     1
+ TESTROW23 |     1
+ TESTROW24 |     1
+ TESTROW25 |     1
+ TESTROW26 |     1
+ TESTROW27 |     1
+ TESTROW28 |     1
+ TESTROW29 |     1
+ TESTROW3  |     1
+ TESTROW30 |     1
+ TESTROW4  |     1
+ TESTROW5  |     1
+ TESTROW6  |     1
+ TESTROW7  |     1
+ TESTROW8  |     1
+ TESTROW9  |     1
+(30 rows)
+
+DROP TABLE issue822;

--- a/test/sql/issue-822.sql
+++ b/test/sql/issue-822.sql
@@ -1,0 +1,25 @@
+CREATE TABLE issue822 (
+                                      id SERIAL8 NOT NULL PRIMARY KEY,
+                                      name text NOT NULL,
+                                      testdate date
+);
+CREATE INDEX es_idxwildcardeddatetest
+    ON issue822 USING zombodb ((issue822.*));
+
+INSERT INTO issue822(name, testdate)
+SELECT 'testrow'||x, '2022-12-01'::date + (x||' days')::interval FROM generate_series(1, 1000) x;
+
+-- should be a prefix query
+select * from zdb.dump_query('issue822', '( testdate  = "2022-12-*" )');
+
+SELECT * FROM issue822 WHERE issue822 ==> '( testdate  = "2022-12-*" )' order by id;
+SELECT * FROM issue822 WHERE issue822 ==> '( testdate  = "2022-12*" )' order by id;
+
+SELECT upper(term) term, count
+FROM zdb.tally('issue822'::regclass,
+               'name',
+               'FALSE',
+               '^.*',
+               '( testdate  = "2022-12*" )'::zdbquery, 2147483647,
+               'count'::termsorderby) order by 1, 2;
+DROP TABLE issue822;


### PR DESCRIPTION
searching with a wildcard at the end of a date (ie, as a prefix query) no longer converts to a proximity query