### PR TITLE
Explore update ERROR/crash

### DIFF
--- a/docker-build-system/package.sh
+++ b/docker-build-system/package.sh
@@ -53,7 +53,7 @@ rustup update || exit 1
 #
 # ensure cargo-pgrx is the correct version and compiled with this Rust version
 #
-cargo install cargo-pgrx --version $PGRX_VERSION
+cargo install cargo-pgrx --version $PGRX_VERSION --locked
 
 #
 # build the extension

--- a/src/access_method/rewriter.rs
+++ b/src/access_method/rewriter.rs
@@ -171,17 +171,17 @@ unsafe fn walk_node(node: NodePtr, context: &mut WalkContext) {
         walk_node(aggref.aggdistinct as NodePtr, context);
         walk_node(aggref.aggfilter as NodePtr, context);
     } else if is_a(node, pg_sys::NodeTag_T_ModifyTable) {
-        let mut modifytable = PgBox::from_pg(node as *mut pg_sys::ModifyTable);
-        walk_plan(&mut modifytable.plan, context);
-        #[cfg(any(feature = "pg10", feature = "pg11", feature = "pg12", feature = "pg13"))]
-        {
-            walk_node(modifytable.plans as NodePtr, context);
-        }
-        #[cfg(any(feature = "pg14", feature = "pg15"))]
-        {
-            walk_node(modifytable.updateColnosLists as NodePtr, context);
-        }
-        walk_node(modifytable.returningLists as NodePtr, context);
+        // let mut modifytable = PgBox::from_pg(node as *mut pg_sys::ModifyTable);
+        // walk_plan(&mut modifytable.plan, context);
+        // #[cfg(any(feature = "pg10", feature = "pg11", feature = "pg12", feature = "pg13"))]
+        // {
+        //     walk_node(modifytable.plans as NodePtr, context);
+        // }
+        // #[cfg(any(feature = "pg14", feature = "pg15"))]
+        // {
+        //     walk_node(modifytable.updateColnosLists as NodePtr, context);
+        // }
+        // walk_node(modifytable.returningLists as NodePtr, context);
     } else if is_a(node, pg_sys::NodeTag_T_LockRows) {
         let mut lockrows = PgBox::from_pg(node as *mut pg_sys::LockRows);
         walk_plan(&mut lockrows.plan, context);

--- a/src/access_method/rewriter.rs
+++ b/src/access_method/rewriter.rs
@@ -6,6 +6,7 @@ struct WalkContext {
     funcoid: pg_sys::Oid,
     targetlists: Vec<*mut pg_sys::List>,
     replacements: HashSet<pg_sys::Oid>,
+    modify_cnt: usize,
 }
 
 type NodePtr = *mut pg_sys::Node;
@@ -29,6 +30,7 @@ pub fn rewrite_opexrs(plan: *mut pg_sys::PlannedStmt) {
             funcoid,
             targetlists: Vec::new(),
             replacements: HashSet::new(),
+            modify_cnt: 0,
         };
 
         walk_node(plan as NodePtr, &mut context);
@@ -108,14 +110,24 @@ unsafe fn walk_plan(plan: *mut pg_sys::Plan, context: &mut WalkContext) {
     }
 
     let plan = PgBox::from_pg(plan);
-    if !is_a(plan.as_ptr() as NodePtr, pg_sys::NodeTag_T_ModifyTable) {
+    let is_modify = is_a(plan.as_ptr() as NodePtr, pg_sys::NodeTag_T_ModifyTable);
+    if is_modify {
+        context.modify_cnt += 1;
+    }
+
+    if context.modify_cnt == 0 {
         context.targetlists.push(plan.targetlist);
     }
+
     walk_node(plan.targetlist as NodePtr, context);
     walk_node(plan.initPlan as NodePtr, context);
     walk_node(plan.lefttree as NodePtr, context);
     walk_node(plan.righttree as NodePtr, context);
     walk_node(plan.qual as NodePtr, context);
+
+    if is_modify {
+        context.modify_cnt -= 1;
+    }
 }
 
 #[allow(clippy::cognitive_complexity)]

--- a/test/expected/test-update-wrong-attribute-type.out
+++ b/test/expected/test-update-wrong-attribute-type.out
@@ -1,0 +1,25 @@
+create table wrongatt (id bigint not null primary key, other_id bigint);
+insert into wrongatt(id) values (1);
+create index idxwrongatt on wrongatt using zombodb ((wrongatt.*));
+create view wrongatt_view as select *, (select array_agg(oid) from pg_class) oids, wrongatt as zdb from wrongatt;
+create or replace function wrongatt_trigger() returns trigger language plpgsql as $$
+BEGIN
+    UPDATE wrongatt SET other_id = 99 WHERE id = OLD.id;
+    RETURN NEW;
+END;
+$$;
+create trigger wrongatt_viewtgr instead of update on wrongatt_view for each row execute function wrongatt_trigger();
+select * from wrongatt where wrongatt ==> 'id:1';
+ id | other_id 
+----+----------
+  1 |         
+(1 row)
+
+update wrongatt_view set other_id = id where id in (select id from wrongatt_view where wrongatt_view.zdb ==> 'id:1');
+select * from wrongatt where wrongatt ==> 'id:1';
+ id | other_id 
+----+----------
+  1 |       99
+(1 row)
+
+drop table wrongatt cascade;

--- a/test/sql/test-update-wrong-attribute-type.sql
+++ b/test/sql/test-update-wrong-attribute-type.sql
@@ -1,0 +1,19 @@
+create table wrongatt (id bigint not null primary key, other_id bigint);
+insert into wrongatt(id) values (1);
+create index idxwrongatt on wrongatt using zombodb ((wrongatt.*));
+create view wrongatt_view as select *, (select array_agg(oid) from pg_class) oids, wrongatt as zdb from wrongatt;
+
+create or replace function wrongatt_trigger() returns trigger language plpgsql as $$
+BEGIN
+    UPDATE wrongatt SET other_id = 99 WHERE id = OLD.id;
+    RETURN NEW;
+END;
+$$;
+create trigger wrongatt_viewtgr instead of update on wrongatt_view for each row execute function wrongatt_trigger();
+
+
+select * from wrongatt where wrongatt ==> 'id:1';
+update wrongatt_view set other_id = id where id in (select id from wrongatt_view where wrongatt_view.zdb ==> 'id:1');
+select * from wrongatt where wrongatt ==> 'id:1';
+
+drop table wrongatt cascade;


### PR DESCRIPTION
It's possible for an UPDATE statement in the form of:  `UPDATE t SET f = 'v' WHERE i IN (SELECT i FROM t WHERE t ==> <zdb query>` to cause an error like:

```
ERROR:  attribute 112 of type record has wrong type
DETAIL:  Table has type tid, but query expects s.t.
```

It also seems a view and trigger needs to be involved.  Definitely an edge-case bug.

Seemingly this can then lead to future segfaults, although I have not been able to recreate the segfault.