### PR TITLE
fix a possible crash during (at least) multi-statement UPDATE transactions.

### DIFF
--- a/src/access_method/triggers.rs
+++ b/src/access_method/triggers.rs
@@ -42,7 +42,7 @@ fn zdb_update_trigger(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
 
         let bulk = get_executor_manager().checkout_bulk_context(index_relid);
         if !bulk.is_shadow {
-            bulk.bulk
+            bulk.es_bulk_request
                 .update(
                     tid,
                     pg_sys::GetCurrentCommandId(true),
@@ -94,7 +94,7 @@ fn zdb_delete_trigger(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum {
 
         let bulk = get_executor_manager().checkout_bulk_context(index_relid);
         if !bulk.is_shadow {
-            bulk.bulk
+            bulk.es_bulk_request
                 .delete(
                     tid,
                     pg_sys::GetCurrentCommandId(true),

--- a/src/json/builder.rs
+++ b/src/json/builder.rs
@@ -43,11 +43,11 @@ enum JsonBuilderValue {
 }
 
 #[derive(Debug)]
-pub struct JsonBuilder<'a> {
-    values: Vec<(&'a str, JsonBuilderValue)>,
+pub struct JsonBuilder {
+    values: Vec<(String, JsonBuilderValue)>,
 }
 
-impl<'a> JsonBuilder<'a> {
+impl JsonBuilder {
     pub fn new(num_fields: usize) -> Self {
         JsonBuilder {
             values: Vec::with_capacity(num_fields + 5),
@@ -55,47 +55,47 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_bool(&mut self, attname: &'a str, value: bool) {
+    pub fn add_bool(&mut self, attname: String, value: bool) {
         self.values.push((attname, JsonBuilderValue::bool(value)));
     }
 
     #[inline]
-    pub fn add_i16(&mut self, attname: &'a str, value: i16) {
+    pub fn add_i16(&mut self, attname: String, value: i16) {
         self.values.push((attname, JsonBuilderValue::i16(value)));
     }
 
     #[inline]
-    pub fn add_i32(&mut self, attname: &'a str, value: i32) {
+    pub fn add_i32(&mut self, attname: String, value: i32) {
         self.values.push((attname, JsonBuilderValue::i32(value)));
     }
 
     #[inline]
-    pub fn add_i64(&mut self, attname: &'a str, value: i64) {
+    pub fn add_i64(&mut self, attname: String, value: i64) {
         self.values.push((attname, JsonBuilderValue::i64(value)));
     }
 
     #[inline]
-    pub fn add_u32(&mut self, attname: &'a str, value: u32) {
+    pub fn add_u32(&mut self, attname: String, value: u32) {
         self.values.push((attname, JsonBuilderValue::u32(value)));
     }
 
     #[inline]
-    pub fn add_u64(&mut self, attname: &'a str, value: u64) {
+    pub fn add_u64(&mut self, attname: String, value: u64) {
         self.values.push((attname, JsonBuilderValue::u64(value)));
     }
 
     #[inline]
-    pub fn add_f32(&mut self, attname: &'a str, value: f32) {
+    pub fn add_f32(&mut self, attname: String, value: f32) {
         self.values.push((attname, JsonBuilderValue::f32(value)));
     }
 
     #[inline]
-    pub fn add_f64(&mut self, attname: &'a str, value: f64) {
+    pub fn add_f64(&mut self, attname: String, value: f64) {
         self.values.push((attname, JsonBuilderValue::f64(value)));
     }
 
     #[inline]
-    pub fn add_time(&mut self, attname: &'a str, value: Time) {
+    pub fn add_time(&mut self, attname: String, value: Time) {
         self.values.push((
             attname,
             JsonBuilderValue::time(ZDBTime(serde_json::to_string(&value).unwrap())),
@@ -103,7 +103,7 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_time_with_time_zone(&mut self, attname: &'a str, value: TimeWithTimeZone) {
+    pub fn add_time_with_time_zone(&mut self, attname: String, value: TimeWithTimeZone) {
         self.values.push((
             attname,
             JsonBuilderValue::time_with_time_zone(ZDBTimeWithTimeZone(
@@ -113,13 +113,13 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_timestamp(&mut self, attname: &'a str, value: Timestamp) {
+    pub fn add_timestamp(&mut self, attname: String, value: Timestamp) {
         self.values
             .push((attname, JsonBuilderValue::timestamp(value.into())));
     }
 
     #[inline]
-    pub fn add_timestamp_with_time_zone(&mut self, attname: &'a str, value: TimestampWithTimeZone) {
+    pub fn add_timestamp_with_time_zone(&mut self, attname: String, value: TimestampWithTimeZone) {
         self.values.push((
             attname,
             JsonBuilderValue::timestamp_with_time_zone(value.into()),
@@ -127,7 +127,7 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_date(&mut self, attname: &'a str, value: Date) {
+    pub fn add_date(&mut self, attname: String, value: Date) {
         self.values.push((
             attname,
             JsonBuilderValue::date(ZDBDate(serde_json::to_string(&value).unwrap())),
@@ -135,71 +135,71 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_string(&mut self, attname: &'a str, value: String) {
+    pub fn add_string(&mut self, attname: String, value: String) {
         self.values.push((attname, JsonBuilderValue::string(value)));
     }
 
     #[inline]
-    pub fn add_json_string(&mut self, attname: &'a str, value: pgrx::JsonString) {
+    pub fn add_json_string(&mut self, attname: String, value: pgrx::JsonString) {
         self.values
             .push((attname, JsonBuilderValue::json_string(value)));
     }
 
     #[inline]
-    pub fn add_jsonb(&mut self, attname: &'a str, value: JsonB) {
+    pub fn add_jsonb(&mut self, attname: String, value: JsonB) {
         self.values.push((attname, JsonBuilderValue::jsonb(value)));
     }
 
     #[inline]
-    pub fn add_json_value(&mut self, attname: &'a str, value: serde_json::Value) {
+    pub fn add_json_value(&mut self, attname: String, value: serde_json::Value) {
         self.values
             .push((attname, JsonBuilderValue::json_value(value)));
     }
 
     #[inline]
-    pub fn add_bool_array(&mut self, attname: &'a str, value: Vec<Option<bool>>) {
+    pub fn add_bool_array(&mut self, attname: String, value: Vec<Option<bool>>) {
         self.values
             .push((attname, JsonBuilderValue::bool_array(value)));
     }
 
     #[inline]
-    pub fn add_i16_array(&mut self, attname: &'a str, value: Vec<Option<i16>>) {
+    pub fn add_i16_array(&mut self, attname: String, value: Vec<Option<i16>>) {
         self.values
             .push((attname, JsonBuilderValue::i16_array(value)));
     }
 
     #[inline]
-    pub fn add_i32_array(&mut self, attname: &'a str, value: Vec<Option<i32>>) {
+    pub fn add_i32_array(&mut self, attname: String, value: Vec<Option<i32>>) {
         self.values
             .push((attname, JsonBuilderValue::i32_array(value)));
     }
 
     #[inline]
-    pub fn add_i64_array(&mut self, attname: &'a str, value: Vec<Option<i64>>) {
+    pub fn add_i64_array(&mut self, attname: String, value: Vec<Option<i64>>) {
         self.values
             .push((attname, JsonBuilderValue::i64_array(value)));
     }
 
     #[inline]
-    pub fn add_u32_array(&mut self, attname: &'a str, value: Vec<Option<u32>>) {
+    pub fn add_u32_array(&mut self, attname: String, value: Vec<Option<u32>>) {
         self.values
             .push((attname, JsonBuilderValue::u32_array(value)));
     }
 
     #[inline]
-    pub fn add_f32_array(&mut self, attname: &'a str, value: Vec<Option<f32>>) {
+    pub fn add_f32_array(&mut self, attname: String, value: Vec<Option<f32>>) {
         self.values
             .push((attname, JsonBuilderValue::f32_array(value)));
     }
 
     #[inline]
-    pub fn add_f64_array(&mut self, attname: &'a str, value: Vec<Option<f64>>) {
+    pub fn add_f64_array(&mut self, attname: String, value: Vec<Option<f64>>) {
         self.values
             .push((attname, JsonBuilderValue::f64_array(value)));
     }
 
     #[inline]
-    pub fn add_time_array(&mut self, attname: &'a str, value: Vec<Option<Time>>) {
+    pub fn add_time_array(&mut self, attname: String, value: Vec<Option<Time>>) {
         let value = value
             .into_iter()
             .map(|t| Some(ZDBTime(serde_json::to_string(&t).unwrap())))
@@ -211,7 +211,7 @@ impl<'a> JsonBuilder<'a> {
     #[inline]
     pub fn add_time_with_time_zone_array(
         &mut self,
-        attname: &'a str,
+        attname: String,
         value: Vec<Option<TimeWithTimeZone>>,
     ) {
         let value = value
@@ -223,7 +223,7 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_timestamp_array(&mut self, attname: &'a str, value: Vec<Option<Timestamp>>) {
+    pub fn add_timestamp_array(&mut self, attname: String, value: Vec<Option<Timestamp>>) {
         self.values.push((
             attname,
             JsonBuilderValue::timestamp_array(
@@ -241,7 +241,7 @@ impl<'a> JsonBuilder<'a> {
     #[inline]
     pub fn add_timestamp_with_time_zone_array(
         &mut self,
-        attname: &'a str,
+        attname: String,
         value: Vec<Option<TimestampWithTimeZone>>,
     ) {
         self.values.push((
@@ -259,7 +259,7 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_date_array(&mut self, attname: &'a str, value: Vec<Option<Date>>) {
+    pub fn add_date_array(&mut self, attname: String, value: Vec<Option<Date>>) {
         let value = value
             .into_iter()
             .map(|t| Some(ZDBDate(serde_json::to_string(&t).unwrap())))
@@ -269,23 +269,19 @@ impl<'a> JsonBuilder<'a> {
     }
 
     #[inline]
-    pub fn add_string_array(&mut self, attname: &'a str, value: Vec<Option<String>>) {
+    pub fn add_string_array(&mut self, attname: String, value: Vec<Option<String>>) {
         self.values
             .push((attname, JsonBuilderValue::string_array(value)));
     }
 
     #[inline]
-    pub fn add_json_string_array(
-        &mut self,
-        attname: &'a str,
-        value: Vec<Option<pgrx::JsonString>>,
-    ) {
+    pub fn add_json_string_array(&mut self, attname: String, value: Vec<Option<pgrx::JsonString>>) {
         self.values
             .push((attname, JsonBuilderValue::json_string_array(value)));
     }
 
     #[inline]
-    pub fn add_jsonb_array(&mut self, attname: &'a str, value: Vec<Option<JsonB>>) {
+    pub fn add_jsonb_array(&mut self, attname: String, value: Vec<Option<JsonB>>) {
         self.values
             .push((attname, JsonBuilderValue::jsonb_array(value)));
     }


### PR DESCRIPTION
ZDB was using a `TupleDesc` after it had been freed.