### PR TITLE
fix issue #852 - querying for an empty array will now `match_none`.

### DIFF
--- a/src/highlighting/document_highlighter.rs
+++ b/src/highlighting/document_highlighter.rs
@@ -465,6 +465,7 @@ impl<'a> DocumentHighlighter<'a> {
     pub fn highlight_term(&'a self, term: &Term) -> Option<HighlightMatches<'a>> {
         match term {
             Term::MatchAll => None,
+            Term::MatchNone => None,
             Term::String(s, _) => self.highlight_token(s),
             Term::Prefix(s, _) => self.highlight_wildcard(s),
             Term::PhrasePrefix(_, _) => unimplemented!("prefix phrases cannot be highlighted"),

--- a/src/highlighting/query_highlighter.rs
+++ b/src/highlighting/query_highlighter.rs
@@ -360,6 +360,9 @@ impl QueryHighlighter {
             Term::MatchAll => {
                 // do nothing
             }
+            Term::MatchNone => {
+                // do nothing
+            }
             Term::String(s, _) => {
                 if let Some(entries) = highlighter.highlight_token(s) {
                     cnt = entries.len();

--- a/src/zql/ast.rs
+++ b/src/zql/ast.rs
@@ -126,6 +126,7 @@ pub enum ComparisonOpcode {
 pub enum Term<'input> {
     Null,
     MatchAll,
+    MatchNone,
     String(&'input str, Option<f32>),
     Phrase(&'input str, Option<f32>),
     Prefix(&'input str, Option<f32>),
@@ -971,6 +972,7 @@ impl<'input> Display for Term<'input> {
             Term::Null => write!(fmt, "NULL"),
 
             Term::MatchAll => write!(fmt, "*"),
+            Term::MatchNone => write!(fmt, "[]"),
 
             Term::String(s, b)
             | Term::Phrase(s, b)

--- a/src/zql/dsl/mod.rs
+++ b/src/zql/dsl/mod.rs
@@ -260,6 +260,11 @@ fn eq(field: &QualifiedField, term: &Term, is_span: bool) -> serde_json::Value {
                 json! { { "exists": { "field": field.field_name() } } }
             }
         }
+
+        Term::MatchNone => {
+            json! { { "match_none": {} } }
+        }
+
         Term::String(s, b) => {
             if s.contains('\\') {
                 let s = unescape(s);
@@ -365,7 +370,10 @@ fn eq(field: &QualifiedField, term: &Term, is_span: bool) -> serde_json::Value {
                 }
             }
 
-            if clauses.len() == 1 {
+            if clauses.is_empty() {
+                // this shouldn't happen as a `field:[]` gets rewritten to Term::MatchNone during parsing
+                json! { { "terms": { field.field_name(): [] } } }
+            } else if clauses.len() == 1 {
                 clauses.pop().unwrap()
             } else {
                 json! { { "bool": { "should": clauses } } }

--- a/src/zql/parser.lalrpop
+++ b/src/zql/parser.lalrpop
@@ -275,8 +275,20 @@ ComparisonOp: ComparisonOpcode = {
 
 Term: Term<'input> = {
     StringExpr => <>,
-    O_BRACKET <v:(<StringExpr> COMMA?)*> C_BRACKET <b:Boost?> => Term::ParsedArray(v, b),
-    <a:UnparsedArray> <b:Boost?> => Term::UnparsedArray(a, b),
+    O_BRACKET <v:(<StringExpr> COMMA?)*> C_BRACKET <b:Boost?> => {
+        if v.is_empty() {
+            Term::MatchNone
+        } else {
+            Term::ParsedArray(v, b)
+        }
+    },
+    <a:UnparsedArray> <b:Boost?> => {
+        if a.trim().is_empty() {
+            Term::MatchNone
+        } else {
+            Term::UnparsedArray(a, b)
+        }
+    },
 };
 
 UnparsedArray: &'input str = {

--- a/test/expected/issue-852.out
+++ b/test/expected/issue-852.out
@@ -1,0 +1,134 @@
+create table issue852 (
+    body text[]
+);
+create index idxissue852 on issue852 using zombodb ((issue852.*));
+insert into issue852(body) values (NULL);
+insert into issue852(body) values (ARRAY[NULL, NULL, NULL]);
+insert into issue852(body) values (ARRAY['a']);
+insert into issue852(body) values (ARRAY['a', 'b']);
+insert into issue852(body) values (ARRAY['a', 'b', 'c']);
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body:[]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body<>[]';
+ count 
+-------
+     5
+(1 row)
+
+select * from zdb.dump_query('idxissue852', 'body:[]');
+     dump_query     
+--------------------
+ {                 +
+   "match_none": {}+
+ }
+(1 row)
+
+select * from zdb.debug_query('idxissue852', 'body:[]');
+ normalized_query | used_fields |                              ast                               
+------------------+-------------+----------------------------------------------------------------
+ body :[]         | {body}      | Contains(                                                     +
+                  |             |     QualifiedField {                                          +
+                  |             |         index: Some(                                          +
+                  |             |             IndexLink(NONE=<public.issue852.idxissue852>NONE),+
+                  |             |         ),                                                    +
+                  |             |         field: "body",                                        +
+                  |             |     },                                                        +
+                  |             |     MatchNone,                                                +
+                  |             | )
+(1 row)
+
+select * from zdb.dump_query('idxissue852', 'body<>[]');
+        dump_query        
+--------------------------
+ {                       +
+   "bool": {             +
+     "must_not": [       +
+       {                 +
+         "match_none": {}+
+       }                 +
+     ]                   +
+   }                     +
+ }
+(1 row)
+
+select * from zdb.debug_query('idxissue852', 'body<>[]');
+ normalized_query | used_fields |                              ast                               
+------------------+-------------+----------------------------------------------------------------
+ body <> []       | {body}      | DoesNotContain(                                               +
+                  |             |     QualifiedField {                                          +
+                  |             |         index: Some(                                          +
+                  |             |             IndexLink(NONE=<public.issue852.idxissue852>NONE),+
+                  |             |         ),                                                    +
+                  |             |         field: "body",                                        +
+                  |             |     },                                                        +
+                  |             |     MatchNone,                                                +
+                  |             | )
+(1 row)
+
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body:[[]]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body<>[[]]';
+ count 
+-------
+     5
+(1 row)
+
+select * from zdb.dump_query('idxissue852', 'body:[[]]');
+     dump_query     
+--------------------
+ {                 +
+   "match_none": {}+
+ }
+(1 row)
+
+select * from zdb.debug_query('idxissue852', 'body:[[]]');
+ normalized_query | used_fields |                              ast                               
+------------------+-------------+----------------------------------------------------------------
+ body :[]         | {body}      | Contains(                                                     +
+                  |             |     QualifiedField {                                          +
+                  |             |         index: Some(                                          +
+                  |             |             IndexLink(NONE=<public.issue852.idxissue852>NONE),+
+                  |             |         ),                                                    +
+                  |             |         field: "body",                                        +
+                  |             |     },                                                        +
+                  |             |     MatchNone,                                                +
+                  |             | )
+(1 row)
+
+select * from zdb.dump_query('idxissue852', 'body<>[[]]');
+        dump_query        
+--------------------------
+ {                       +
+   "bool": {             +
+     "must_not": [       +
+       {                 +
+         "match_none": {}+
+       }                 +
+     ]                   +
+   }                     +
+ }
+(1 row)
+
+select * from zdb.debug_query('idxissue852', 'body<>[[]]');
+ normalized_query | used_fields |                              ast                               
+------------------+-------------+----------------------------------------------------------------
+ body <> []       | {body}      | DoesNotContain(                                               +
+                  |             |     QualifiedField {                                          +
+                  |             |         index: Some(                                          +
+                  |             |             IndexLink(NONE=<public.issue852.idxissue852>NONE),+
+                  |             |         ),                                                    +
+                  |             |         field: "body",                                        +
+                  |             |     },                                                        +
+                  |             |     MatchNone,                                                +
+                  |             | )
+(1 row)
+
+drop table issue852;

--- a/test/sql/issue-852.sql
+++ b/test/sql/issue-852.sql
@@ -1,0 +1,25 @@
+create table issue852 (
+    body text[]
+);
+create index idxissue852 on issue852 using zombodb ((issue852.*));
+insert into issue852(body) values (NULL);
+insert into issue852(body) values (ARRAY[NULL, NULL, NULL]);
+insert into issue852(body) values (ARRAY['a']);
+insert into issue852(body) values (ARRAY['a', 'b']);
+insert into issue852(body) values (ARRAY['a', 'b', 'c']);
+
+
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body:[]';
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body<>[]';
+select * from zdb.dump_query('idxissue852', 'body:[]');
+select * from zdb.debug_query('idxissue852', 'body:[]');
+select * from zdb.dump_query('idxissue852', 'body<>[]');
+select * from zdb.debug_query('idxissue852', 'body<>[]');
+
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body:[[]]';
+SELECT count(*) FROM issue852 WHERE issue852 ==> 'body<>[[]]';
+select * from zdb.dump_query('idxissue852', 'body:[[]]');
+select * from zdb.debug_query('idxissue852', 'body:[[]]');
+select * from zdb.dump_query('idxissue852', 'body<>[[]]');
+select * from zdb.debug_query('idxissue852', 'body<>[[]]');
+drop table issue852;


### PR DESCRIPTION
This required inventing that new Term variant and plumbing it through the code.