### PR TITLE
fix issue #861

### DIFF
--- a/src/highlighting/query_highlighter.rs
+++ b/src/highlighting/query_highlighter.rs
@@ -358,7 +358,10 @@ impl QueryHighlighter {
         let mut cnt = 0;
         match term {
             Term::MatchAll => {
-                // do nothing
+                if let Some(entries) = highlighter.highlight_regex(".*") {
+                    cnt = entries.len();
+                    QueryHighlighter::process_entries(expr, &field, entries, highlights);
+                }
             }
             Term::MatchNone => {
                 // do nothing

--- a/test/expected/issue-861.out
+++ b/test/expected/issue-861.out
@@ -1,0 +1,42 @@
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* and body:*') order by 1, 2, 3;
+ field_name | array_index | term |      type      | position | start_offset | end_offset | query_clause 
+------------+-------------+------+----------------+----------+--------------+------------+--------------
+ body       |           0 | java | <ALPHANUM>     |        1 |            0 |          4 | body:*
+ id         |           0 | 42   | <UNSIGNED_INT> |        1 |            0 |          0 | id:*
+(2 rows)
+
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* and body:java') order by 1, 2, 3;
+ field_name | array_index | term |      type      | position | start_offset | end_offset | query_clause 
+------------+-------------+------+----------------+----------+--------------+------------+--------------
+ body       |           0 | java | <ALPHANUM>     |        1 |            0 |          4 | body:"java"
+ id         |           0 | 42   | <UNSIGNED_INT> |        1 |            0 |          0 | id:*
+(2 rows)
+
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:42 and body:*') order by 1, 2, 3;
+ field_name | array_index | term |      type      | position | start_offset | end_offset | query_clause 
+------------+-------------+------+----------------+----------+--------------+------------+--------------
+ body       |           0 | java | <ALPHANUM>     |        1 |            0 |          4 | body:*
+ id         |           0 | 42   | <UNSIGNED_INT> |        1 |            0 |          0 | id:"42"
+(2 rows)
+
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* or body:*') order by 1, 2, 3;
+ field_name | array_index | term |      type      | position | start_offset | end_offset | query_clause 
+------------+-------------+------+----------------+----------+--------------+------------+--------------
+ body       |           0 | java | <ALPHANUM>     |        1 |            0 |          4 | body:*
+ id         |           0 | 42   | <UNSIGNED_INT> |        1 |            0 |          0 | id:*
+(2 rows)
+
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* or body:java') order by 1, 2, 3;
+ field_name | array_index | term |      type      | position | start_offset | end_offset | query_clause 
+------------+-------------+------+----------------+----------+--------------+------------+--------------
+ body       |           0 | java | <ALPHANUM>     |        1 |            0 |          4 | body:"java"
+ id         |           0 | 42   | <UNSIGNED_INT> |        1 |            0 |          0 | id:*
+(2 rows)
+
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:42 or body:*') order by 1, 2, 3;
+ field_name | array_index | term |      type      | position | start_offset | end_offset | query_clause 
+------------+-------------+------+----------------+----------+--------------+------------+--------------
+ body       |           0 | java | <ALPHANUM>     |        1 |            0 |          4 | body:*
+ id         |           0 | 42   | <UNSIGNED_INT> |        1 |            0 |          0 | id:"42"
+(2 rows)
+

--- a/test/sql/issue-861.sql
+++ b/test/sql/issue-861.sql
@@ -1,0 +1,6 @@
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* and body:*') order by 1, 2, 3;
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* and body:java') order by 1, 2, 3;
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:42 and body:*') order by 1, 2, 3;
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* or body:*') order by 1, 2, 3;
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:* or body:java') order by 1, 2, 3;
+select * from zdb.highlight_document('so_posts', '{"body": "java", "id":42}'::json, 'id:42 or body:*') order by 1, 2, 3;


### PR DESCRIPTION
`zdb.highlight_document()` now properly understands the bare `*` (MatchAll) wildcard