### PR TITLE
Fix issue #863

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6186d4aa5911be4c00b52e555779deece35a7563c87fcfe794407dc2e9cc4dc1"
+checksum = "0e80e25d7f85997d5d24c824297529bcb73231bbdc74d77906004d41cd3ffee3"
 dependencies = [
  "atomic-traits",
  "bitflags 2.3.3",
@@ -1247,9 +1247,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479a66a8c582e0fdf101178473315cb13eaa10829c154db742c35ec0279cdaec"
+checksum = "999ef782b36bb511806277f2a74a7f9e075edcad8c9439a3b90f4c90384f2a29"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45c557631217a13859e223899c01d35982ef0c860ee5ab65af496f830b1316"
+checksum = "a7b27ccd3d892e3b27bcb7a6e2bf86588d82fad3da622db168261bc6b534a737"
 dependencies = [
  "cargo_toml",
  "dirs",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde896a17c638b6475d6fc12b571a176013a8486437bbc8a64ac2afb8ba5d58"
+checksum = "c0767fdf6930ba6fa2d1b1934313aae3694b70732e0b6169ece26b03de27f8dc"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e9abc71b018d90aa9b7a34fedf48b76da5d55c04d2ed2288096827bebbf403"
+checksum = "4d632abaa9c3da42e5e2a17a6268afb0449a7f655764c65e06695ee55763ff0e"
 dependencies = [
  "convert_case",
  "eyre",
@@ -1314,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ac4ffedfa247f9d51421e4e2ac18c33d8d674350bad730f3fe5736bf298612"
+checksum = "d44327bd084bcdc6fe4e72dfce8065e23b5b4522f36d63d14ee21c5000e7c73c"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1327,6 +1327,7 @@ dependencies = [
  "pgrx-macros",
  "pgrx-pg-config",
  "postgres",
+ "rand",
  "regex",
  "serde",
  "serde_json",
@@ -1442,9 +1443,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ lazy_static = "1.4.0"
 levenshtein = "1.0.5"
 memoffset = "0.9.0"
 num_cpus = "1.16.0"
-pgrx = "=0.9.7"
+pgrx = "=0.9.8"
 rayon = "1.7.0"
 regex = { version = "1.8.4", features = [ "unicode-case"] }
 rustc-hash = "1.1.0"
@@ -49,7 +49,7 @@ lalrpop = "0.20.0"
 built = { version = "0.6.1", features = [ "git2", "semver" ] }
 
 [dev-dependencies]
-pgrx-tests = "=0.9.7"
+pgrx-tests = "=0.9.8"
 libc = "0.2.147"
 
 [profile.dev]

--- a/test/expected/issue-812.out
+++ b/test/expected/issue-812.out
@@ -16,20 +16,16 @@ from (
     zdb.highlight_document('wi60341.hili_recreate'::regclass,to_json(crv),
                            'data_full_text:("Duis*" W/3 "aute*")'::text) as highlights ON true
 order by position, start_offset, end_offset, term;
-   field_name   | array_index |   term    |    type    | position | start_offset | end_offset |             query_clause             
-----------------+-------------+-----------+------------+----------+--------------+------------+--------------------------------------
- data_full_text |           0 | duis      | <ALPHANUM> |       37 |          232 |        236 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | duis$aute | shingle    |       37 |          232 |        241 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | aute      | <ALPHANUM> |       38 |          237 |        241 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | duis      | <ALPHANUM> |      106 |          678 |        682 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | duis$aute | shingle    |      106 |          678 |        687 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | aute      | <ALPHANUM> |      107 |          683 |        687 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | duis      | <ALPHANUM> |      175 |         1124 |       1128 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | duis$aute | shingle    |      175 |         1124 |       1133 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | aute      | <ALPHANUM> |      176 |         1129 |       1133 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | duis      | <ALPHANUM> |      244 |         1570 |       1574 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | duis$aute | shingle    |      244 |         1570 |       1579 | data_full_text:("duis*" W/3 "aute*")
- data_full_text |           0 | aute      | <ALPHANUM> |      245 |         1575 |       1579 | data_full_text:("duis*" W/3 "aute*")
-(12 rows)
+   field_name   | array_index | term |    type    | position | start_offset | end_offset |             query_clause             
+----------------+-------------+------+------------+----------+--------------+------------+--------------------------------------
+ data_full_text |           0 | duis | <ALPHANUM> |       37 |          232 |        236 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |       38 |          237 |        241 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | duis | <ALPHANUM> |      106 |          678 |        682 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |      107 |          683 |        687 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | duis | <ALPHANUM> |      175 |         1124 |       1128 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |      176 |         1129 |       1133 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | duis | <ALPHANUM> |      244 |         1570 |       1574 | data_full_text:("duis*" W/3 "aute*")
+ data_full_text |           0 | aute | <ALPHANUM> |      245 |         1575 |       1579 | data_full_text:("duis*" W/3 "aute*")
+(8 rows)
 
 drop schema wi60341 cascade;

--- a/test/expected/issue-836.out
+++ b/test/expected/issue-836.out
@@ -9,12 +9,14 @@ select * from zdb.highlight_document('issue836', (select row_to_json(issue836) f
  field_name | array_index | term |   type    | position | start_offset | end_offset | query_clause 
 ------------+-------------+------+-----------+----------+--------------+------------+--------------
  b          |           0 | true | <BOOLEAN> |        1 |            0 |          0 | b:"true"
-(1 row)
+ b          |           0 | true | <BOOLEAN> |        1 |            0 |          0 | b:"true"
+(2 rows)
 
 select * from zdb.highlight_document('issue836', (select row_to_json(issue836) from issue836 where b = false), 'b:true or b:false or b:TRUE or b:FALSE or b:NOT_a_Boolean', false);
  field_name | array_index | term  |   type    | position | start_offset | end_offset | query_clause 
 ------------+-------------+-------+-----------+----------+--------------+------------+--------------
  b          |           0 | false | <BOOLEAN> |        1 |            0 |          0 | b:"false"
-(1 row)
+ b          |           0 | false | <BOOLEAN> |        1 |            0 |          0 | b:"false"
+(2 rows)
 
 drop table issue836 cascade;

--- a/test/expected/issue-863.out
+++ b/test/expected/issue-863.out
@@ -1,0 +1,20 @@
+CREATE TABLE issue863
+(
+    id        SERIAL8                    NOT NULL PRIMARY KEY,
+    full_text zdb.fulltext_with_shingles NOT NULL
+);
+CREATE INDEX idxissue863
+    ON issue863 USING zombodb ((issue863.*));
+INSERT INTO issue863(full_text)
+values ('It is rumored that they were one of Cleopatra''s prized beauty secrets. Pickles have been around for thousands of years, dating as far back as 2030 BC when cucumbers from their native India were pickled in the Tigris Valley.');
+SELECT *
+FROM zdb.highlight_document('issue863',
+                            '{"full_text": "It is rumored that they were one of Cleopatra''s prized beauty secrets. Pickles have been around for thousands of years, dating as far back as 2030 BC when cucumbers from their native India were pickled in the Tigris Valley."}'::json,
+                            '( full_text:("thousands of years") )'::TEXT);
+ field_name | array_index |     term     |  type   | position | start_offset | end_offset |          query_clause          
+------------+-------------+--------------+---------+----------+--------------+------------+--------------------------------
+ full_text  |           0 | thousands$of | shingle |       18 |          100 |        112 | full_text:"thousands of years"
+ full_text  |           0 | of$years     | shingle |       19 |          110 |        118 | full_text:"thousands of years"
+(2 rows)
+
+DROP TABLE issue863;

--- a/test/sql/issue-863.sql
+++ b/test/sql/issue-863.sql
@@ -1,0 +1,17 @@
+CREATE TABLE issue863
+(
+    id        SERIAL8                    NOT NULL PRIMARY KEY,
+    full_text zdb.fulltext_with_shingles NOT NULL
+);
+CREATE INDEX idxissue863
+    ON issue863 USING zombodb ((issue863.*));
+
+INSERT INTO issue863(full_text)
+values ('It is rumored that they were one of Cleopatra''s prized beauty secrets. Pickles have been around for thousands of years, dating as far back as 2030 BC when cucumbers from their native India were pickled in the Tigris Valley.');
+
+SELECT *
+FROM zdb.highlight_document('issue863',
+                            '{"full_text": "It is rumored that they were one of Cleopatra''s prized beauty secrets. Pickles have been around for thousands of years, dating as far back as 2030 BC when cucumbers from their native India were pickled in the Tigris Valley."}'::json,
+                            '( full_text:("thousands of years") )'::TEXT);
+
+DROP TABLE issue863;


### PR DESCRIPTION
This adjusts hit highlighting to only remove "shingle" hits during final hit de-duplication if the "shingle" hit is not unique relative to the current hit being emitted.

This does adjust the expected output for issue #812, but after discussion with @Shigoki, we believe this is the correct behavior.

Also updates pgrx to 0.9.8.