### PR TITLE
Fix issue #867

### DIFF
--- a/src/zql/transformations/index_links.rs
+++ b/src/zql/transformations/index_links.rs
@@ -12,18 +12,9 @@ pub fn assign_links<'a>(
     match determine_link(original_index, root_index, expr, indexes) {
         // everything belongs to the same link (that isn't the root_index), and whatever that is we wrapped it in an Expr::Linked
         Some(target_link) if &target_link.qualified_index != &root_index.qualified_index => {
-            match expr {
-                Expr::Not(inner) => {
-                    let dummy = Box::new(Expr::Null);
-                    let swapped = std::mem::replace(inner, dummy);
-                    *expr = Expr::Not(Box::new(Expr::Linked(target_link, swapped)))
-                }
-                _ => {
-                    let dummy = Expr::Null;
-                    let swapped = std::mem::replace(expr, dummy);
-                    *expr = Expr::Linked(target_link, Box::new(swapped));
-                }
-            }
+            let dummy = Expr::Null;
+            let swapped = std::mem::replace(expr, dummy);
+            *expr = Expr::Linked(target_link, Box::new(swapped));
         }
 
         // there's more than one link or it's the root_index and they've already been linked

--- a/src/zql/transformations/merge_index_links.rs
+++ b/src/zql/transformations/merge_index_links.rs
@@ -1,0 +1,102 @@
+use crate::zql::ast::{Expr, IndexLink};
+use std::collections::HashMap;
+
+pub fn merge_adjacent_links(expr: &mut Expr) -> bool {
+    let mut changed = false;
+    match expr {
+        Expr::Null => {}
+        Expr::Not(e) => {
+            changed |= merge_adjacent_links(e);
+            if e.is_linked() {
+                let dummy = Box::new(Expr::Null);
+                let swapped = std::mem::replace(e, dummy);
+                if let Expr::Linked(link, inner) = *swapped {
+                    *expr = Expr::Linked(link, Box::new(Expr::Not(inner)));
+                } else {
+                    unreachable!("it wasn't an Expr::Linked")
+                }
+            }
+        }
+        Expr::WithList(v) => {
+            changed |= do_merge(v, |members| Expr::WithList(members));
+            if v.len() == 1 {
+                *expr = v.pop().unwrap();
+            }
+        }
+        Expr::AndList(v) => {
+            changed |= do_merge(v, |members| Expr::AndList(members));
+            if v.len() == 1 {
+                *expr = v.pop().unwrap();
+            }
+        }
+        Expr::OrList(v) => {
+            changed |= do_merge(v, |members| Expr::OrList(members));
+            if v.len() == 1 {
+                *expr = v.pop().unwrap();
+            }
+        }
+        Expr::Linked(_, e) => changed |= merge_adjacent_links(e),
+        Expr::Nested(_, e) => changed |= merge_adjacent_links(e),
+        Expr::Subselect(_, e) => changed |= merge_adjacent_links(e),
+        Expr::Expand(_, e, f) => {
+            changed |= merge_adjacent_links(e);
+            if f.is_some() {
+                changed |= merge_adjacent_links(f.as_deref_mut().unwrap());
+            }
+        }
+        Expr::Json(_) => {}
+        Expr::Contains(_, _) => {}
+        Expr::Eq(_, _) => {}
+        Expr::Gt(_, _) => {}
+        Expr::Lt(_, _) => {}
+        Expr::Gte(_, _) => {}
+        Expr::Lte(_, _) => {}
+        Expr::Ne(_, _) => {}
+        Expr::DoesNotContain(_, _) => {}
+        Expr::Regex(_, _) => {}
+        Expr::MoreLikeThis(_, _) => {}
+        Expr::FuzzyLikeThis(_, _) => {}
+        Expr::Matches(_, _) => {}
+    }
+
+    if changed {
+        changed = merge_adjacent_links(expr);
+    }
+    changed
+}
+
+fn do_merge<F: Fn(Vec<Expr>) -> Expr>(v: &mut Vec<Expr>, group_func: F) -> bool {
+    let many = v.len();
+    let mut changed = false;
+
+    // group the elements of `v` together by their Some(IndexLink) or None
+    let mut groups = HashMap::<Option<IndexLink>, Vec<Expr>>::new();
+    for mut e in v.drain(..) {
+        changed |= merge_adjacent_links(&mut e);
+
+        let (link, inner) = if let Expr::Linked(link, inner) = e {
+            (Some(link), *inner)
+        } else {
+            (None, e)
+        };
+
+        groups.entry(link).or_default().push(inner);
+    }
+
+    for (link, mut members) in groups {
+        match link {
+            Some(link) => {
+                if members.len() == 1 {
+                    v.push(Expr::Linked(link, Box::new(members.pop().unwrap())));
+                } else {
+                    v.push(Expr::Linked(link, Box::new(group_func(members))));
+                }
+            }
+            None => v.extend(members),
+        }
+    }
+
+    changed |= v.len() != many;
+
+    changed
+}

--- a/src/zql/transformations/mod.rs
+++ b/src/zql/transformations/mod.rs
@@ -5,3 +5,4 @@ pub(crate) mod field_lists;
 pub(crate) mod index_links;
 pub(crate) mod nested_groups;
 pub(crate) mod prox_rewriter;
+pub(crate) mod merge_index_links;

--- a/test/expected/issue-679.out
+++ b/test/expected/issue-679.out
@@ -1,18 +1,18 @@
 alter index idxso_posts set (options='user_data:(owner_user_id=<public.so_users.idxso_users>id)');
 alter index idxso_posts set (max_terms_count = 10131072);
-select zdb.count('so_posts', 'not user_data.id:-1');
+select zdb.count('so_posts', '(not user_data.id:-1 or owner_user_id = null)');
  count  
 --------
  164867
 (1 row)
 
-select zdb.count('so_posts', 'not user_data.id:-1 or user_data.id:-1');
+select zdb.count('so_posts', '(not user_data.id:-1 or owner_user_id = null) or user_data.id:-1');
  count  
 --------
  165240
 (1 row)
 
-select zdb.count('so_posts', '(not user_data.id:-1 or user_data.id:-1 and user_data.id:-1) not user_data.id:-1');
+select zdb.count('so_posts', '((not user_data.id:-1 or owner_user_id = null) or user_data.id:-1 and user_data.id:-1) and (not user_data.id:-1 or owner_user_id = null)');
  count  
 --------
  164867

--- a/test/expected/issue-867.out
+++ b/test/expected/issue-867.out
@@ -1,0 +1,65 @@
+CREATE TABLE main
+(
+    id   bigint,
+    name varchar
+);
+CREATE TABLE other
+(
+    other_id bigint,
+    fk_main  bigint[],
+    a        varchar,
+    b        varchar[],
+    c        varchar,
+    d        varchar[]
+);
+CREATE VIEW other_view AS
+SELECT other.other_id,
+       other.fk_main,
+       other.a,
+       other.b,
+       other.c,
+       other.d,
+       (select array_agg(name) from main where id = ANY (fk_main)) name,
+       other as                                                    zdb
+FROM other;
+CREATE INDEX idxmain ON main USING zombodb ((main.*));
+CREATE INDEX idxother ON other USING zombodb ((other.*)) WITH (options = 'fk_main=<public.main.idxmain>id');
+INSERT INTO main (id, name)
+VALUES (1, 'Brandy');
+-- insert a record that would match the query if the outer NOT wasn't there
+INSERT INTO other (other_id, fk_main, a, b, c, d)
+VALUES (100, '{1}', 'A', '{B}', 'C', '{D}');
+-- insert a record that matches the query as it's written
+INSERT INTO other (other_id, fk_main, a, b, c, d)
+VALUES (100, '{1}', 'not_A', '{B}', 'C', '{not_D}');
+SELECT a, b, c, d, fk_main, name
+FROM other_view
+WHERE
+              NOT
+                  (
+                      a = 'A' OR a = 'Y' OR a = 'YES'
+                  )
+              AND
+                  (
+                      'B' = ANY (b) AND (c = 'C' OR c = 'YES' OR c IS NULL) AND 'D' <> ANY (d)
+                  )
+ORDER BY other_id;
+   a   |  b  | c |    d    | fk_main |   name   
+-------+-----+---+---------+---------+----------
+ not_A | {B} | C | {not_D} | {1}     | {Brandy}
+(1 row)
+
+SELECT *
+FROM zdb.tally('other_view', 'name', false, '^b.*', '( (NOT ((a: "A" OR a: Y OR
+                                                     a: YES) )) AND
+                                                     (((b = B AND
+                                                          (c = C OR c = YES OR c = NULL)
+                                                     AND d <> D))))', 10, 'term');
+  term  | count 
+--------+-------
+ brandy |     1
+(1 row)
+
+DROP VIEW other_view;
+DROP TABLE other;
+DROP TABLE main;

--- a/test/sql/issue-679.sql
+++ b/test/sql/issue-679.sql
@@ -1,7 +1,7 @@
 alter index idxso_posts set (options='user_data:(owner_user_id=<public.so_users.idxso_users>id)');
 alter index idxso_posts set (max_terms_count = 10131072);
-select zdb.count('so_posts', 'not user_data.id:-1');
-select zdb.count('so_posts', 'not user_data.id:-1 or user_data.id:-1');
-select zdb.count('so_posts', '(not user_data.id:-1 or user_data.id:-1 and user_data.id:-1) not user_data.id:-1');
+select zdb.count('so_posts', '(not user_data.id:-1 or owner_user_id = null)');
+select zdb.count('so_posts', '(not user_data.id:-1 or owner_user_id = null) or user_data.id:-1');
+select zdb.count('so_posts', '((not user_data.id:-1 or owner_user_id = null) or user_data.id:-1 and user_data.id:-1) and (not user_data.id:-1 or owner_user_id = null)');
 alter index idxso_posts reset(options);
 alter index idxso_posts reset(max_terms_count);

--- a/test/sql/issue-867.sql
+++ b/test/sql/issue-867.sql
@@ -1,0 +1,65 @@
+CREATE TABLE main
+(
+    id   bigint,
+    name varchar
+);
+
+CREATE TABLE other
+(
+    other_id bigint,
+    fk_main  bigint[],
+    a        varchar,
+    b        varchar[],
+    c        varchar,
+    d        varchar[]
+);
+
+CREATE VIEW other_view AS
+SELECT other.other_id,
+       other.fk_main,
+       other.a,
+       other.b,
+       other.c,
+       other.d,
+       (select array_agg(name) from main where id = ANY (fk_main)) name,
+       other as                                                    zdb
+FROM other;
+
+CREATE INDEX idxmain ON main USING zombodb ((main.*));
+CREATE INDEX idxother ON other USING zombodb ((other.*)) WITH (options = 'fk_main=<public.main.idxmain>id');
+
+INSERT INTO main (id, name)
+VALUES (1, 'Brandy');
+
+-- insert a record that would match the query if the outer NOT wasn't there
+INSERT INTO other (other_id, fk_main, a, b, c, d)
+VALUES (100, '{1}', 'A', '{B}', 'C', '{D}');
+
+-- insert a record that matches the query as it's written
+INSERT INTO other (other_id, fk_main, a, b, c, d)
+VALUES (100, '{1}', 'not_A', '{B}', 'C', '{not_D}');
+
+SELECT a, b, c, d, fk_main, name
+FROM other_view
+WHERE
+
+              NOT
+                  (
+                      a = 'A' OR a = 'Y' OR a = 'YES'
+                  )
+              AND
+                  (
+                      'B' = ANY (b) AND (c = 'C' OR c = 'YES' OR c IS NULL) AND 'D' <> ANY (d)
+                  )
+ORDER BY other_id;
+
+SELECT *
+FROM zdb.tally('other_view', 'name', false, '^b.*', '( (NOT ((a: "A" OR a: Y OR
+                                                     a: YES) )) AND
+                                                     (((b = B AND
+                                                          (c = C OR c = YES OR c = NULL)
+                                                     AND d <> D))))', 10, 'term');
+
+DROP VIEW other_view;
+DROP TABLE other;
+DROP TABLE main;


### PR DESCRIPTION
The unary `NOT` operator is now pushed down into `Expr::Linked` nodes which is where it should be.  This ensures we're not retrieving values from ES that we shouldn't, which may not be properly filtered if the NOT was on the outside.

This does change the test around issue #679, but that was fixed incorrectly in the first place, which lead to this bug.