### PR TITLE
Fix issue #869

### DIFF
--- a/test/expected/issue-869.out
+++ b/test/expected/issue-869.out
@@ -1,0 +1,10 @@
+UPDATE so_posts SET id = id;
+VACUUM (PARALLEL 8) so_posts;
+SELECT zdb.count('idxso_posts', match_all()),
+       zdb.raw_count('idxso_posts', match_all()),
+       zdb.count('idxso_posts', match_all())+1 = zdb.raw_count('idxso_posts', match_all());
+ count  | raw_count | ?column? 
+--------+-----------+----------
+ 165240 |    165241 | t
+(1 row)
+

--- a/test/sql/issue-869.sql
+++ b/test/sql/issue-869.sql
@@ -1,0 +1,6 @@
+UPDATE so_posts SET id = id;
+VACUUM (PARALLEL 8) so_posts;
+
+SELECT zdb.count('idxso_posts', match_all()),
+       zdb.raw_count('idxso_posts', match_all()),
+       zdb.count('idxso_posts', match_all())+1 = zdb.raw_count('idxso_posts', match_all());


### PR DESCRIPTION
`VACUUM (PARALLEL)` no longer cancels itself.

There's some other little cleanup here around returning an `IndexBulkDeleteResult` just to be consistent with how the other core Postgres index types do it.