### PR TITLE
Add TLS support in Elasticsearch client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ foo.*
 /regression.diffs
 /regression.out
 /src/zql/parser.rs
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,6 +632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,6 +652,21 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1085,6 +1116,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,6 +1191,50 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "openssl"
+version = "0.10.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+dependencies = [
+ "bitflags 2.3.3",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -1646,6 +1739,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1792,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,6 +1821,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1952,6 +2098,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2197,8 +2356,10 @@ dependencies = [
  "base64",
  "flate2",
  "log",
+ "native-tls",
  "once_cell",
  "rustls",
+ "rustls-native-certs",
  "rustls-webpki 0.100.1",
  "serde",
  "serde_json",
@@ -2456,6 +2617,7 @@ dependencies = [
  "levenshtein",
  "libc",
  "memoffset",
+ "native-tls",
  "num_cpus",
  "pgrx",
  "pgrx-tests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ pg12 = [ "pgrx/pg12", "pgrx-tests/pg12" ]
 pg13 = [ "pgrx/pg13", "pgrx-tests/pg13" ]
 pg14 = [ "pgrx/pg14", "pgrx-tests/pg14" ]
 pg15 = [ "pgrx/pg15", "pgrx-tests/pg15" ]
-pg_test = [ ]
+native_tls = [ "native-tls", "ureq/native-tls" ]
+rustls_native_certs = [ "ureq/native-certs" ]
+pg_test = []
 
 [dependencies]
 byteorder = "1.4.3"
@@ -43,6 +45,7 @@ sqlformat = "0.2.1"
 unicode-segmentation = "1.10.1"
 ureq = { version = "2.7.1", features = [ "json" ] }
 url = "2.4.0"
+native-tls = { version = "0.2.11", optional = true }
 
 [build-dependencies]
 lalrpop = "0.20.0"

--- a/SOURCE-INSTALLATION.md
+++ b/SOURCE-INSTALLATION.md
@@ -48,6 +48,22 @@ the above command will need write permissions to the Postgres `$PG_INSTALL_PATH/
 Updating ZomboDB from sources will simply require a `git pull`, another `make clean install` and running
 `ALTER EXTENSION zombodb UPDATE;` in all databases that use the ZomboDB extension.
 
+## TLS Support via `rustls`
+ZomboDB supports TLS connections to Elasticsearch via the `rustls` and `native-tls` crates. By default, ZomboDB is compiled with `rustls` support. By default it will trust [webpki-roots](https://docs.rs/webpki-roots/latest/webpki_roots/), a copy of the Mozilla Root program that is bundled into ZomboDB.
+
+If you want to use custom certificates you will need to enable `rustls_native_certs` feature when building ZomboDB. This will use the OS certificate verifier and trust store. 
+
+> [!NOTE]  
+> If you want to load a certificate from the file - you can set the `SSL_CERT_FILE` environment variable to the path of the certificate file.
+
+
+## Enabling TLS Support via `native-tls`
+By default, ZomboDB is compiled with `rustls` support.  If you'd like to use `native-tls` instead, you'll need to enable the `native_tls` feature when building ZomboDB.
+
+Both `rustls` and `native-tls` support TLS connections via the `https` scheme. Both features will use the OS certificate verifier and trust store.
+
+You may want to use `native-tls` if you are using TLS 1.1 or 1.0, as `rustls` does not support these older TLS versions or if you need to validate the certificates for IP addresses.
+
 ## Building Binary Artifacts with Docker
 
 If you have a proper Docker installation you can simply run:

--- a/src/elasticsearch/mod.rs
+++ b/src/elasticsearch/mod.rs
@@ -52,11 +52,6 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::io::Read;
 
-#[cfg(feature = "native_tls")]
-use crate::gucs::ZDB_LOG_LEVEL;
-#[cfg(feature = "native_tls")]
-use std::sync::Arc;
-
 lazy_static! {
     static ref NUM_CPUS: usize = num_cpus::get();
 }
@@ -144,14 +139,14 @@ impl Elasticsearch {
                     match native_tls::TlsConnector::new() {
                         Ok(tls_config) => {
                             return agent_builder
-                            .tls_connector(Arc::new(tls_config))
+                            .tls_connector(std::sync::Arc::new(tls_config))
                             .timeout_read(std::time::Duration::from_secs(3600))  // a 1hr timeout waiting on ES to return
                             .max_idle_connections_per_host(num_cpus::get())     // 1 for each CPU -- only really used during _bulk
                             .build();
                         }
                         Err(e) => {
                             // log the error
-                            ZDB_LOG_LEVEL.get().log(&format!(
+                            crate::gucs::ZDB_LOG_LEVEL.get().log(&format!(
                                 "[zombodb] can't create native tls connector - {}",
                                 e
                             ));


### PR DESCRIPTION
This PR adds TLS support either via controllable feature-flags through the following crates:
- `rustls` (along with native OS certs)
- `native-tls`

I have added some documentation entries to explain how it works. Tested against self-signed certificates generated with `elasticsearch-certutil` on version 8.9.1. 

Solves: 
- https://github.com/zombodb/zombodb/issues/872
- https://github.com/zombodb/zombodb/issues/827