### PR TITLE
Follow up fix for #807

### DIFF
--- a/src/highlighting/document_highlighter.rs
+++ b/src/highlighting/document_highlighter.rs
@@ -417,42 +417,46 @@ impl<'a> DocumentHighlighter<'a> {
     }
 
     pub fn gt_func(&self) -> fn(&str, &str) -> bool {
-        match self.data_type.as_ref().unwrap() {
-            DataType::String => str::gt,
-            DataType::Float => |token: &str, term: &str| compare_float!(token, gt, term),
-            DataType::Integer => |token: &str, term: &str| compare_integer!(token, gt, term),
-            DataType::Date => |token: &str, term: &str| compare_date!(token, gt, term),
-            DataType::Bool => |_, _| false,
+        match &self.data_type {
+            Some(DataType::String) => str::gt,
+            Some(DataType::Float) => |token: &str, term: &str| compare_float!(token, gt, term),
+            Some(DataType::Integer) => |token: &str, term: &str| compare_integer!(token, gt, term),
+            Some(DataType::Date) => |token: &str, term: &str| compare_date!(token, gt, term),
+            Some(DataType::Bool) => |_, _| false,
+            None => |_, _| false,
         }
     }
 
     pub fn lt_func(&self) -> fn(&str, &str) -> bool {
-        match self.data_type.as_ref().unwrap() {
-            DataType::String => str::lt,
-            DataType::Float => |token: &str, term: &str| compare_float!(token, lt, term),
-            DataType::Integer => |token: &str, term: &str| compare_integer!(token, lt, term),
-            DataType::Date => |token: &str, term: &str| compare_date!(token, lt, term),
-            DataType::Bool => |_, _| false,
+        match &self.data_type {
+            Some(DataType::String) => str::lt,
+            Some(DataType::Float) => |token: &str, term: &str| compare_float!(token, lt, term),
+            Some(DataType::Integer) => |token: &str, term: &str| compare_integer!(token, lt, term),
+            Some(DataType::Date) => |token: &str, term: &str| compare_date!(token, lt, term),
+            Some(DataType::Bool) => |_, _| false,
+            None => |_, _| false,
         }
     }
 
     pub fn ge_func(&self) -> fn(&str, &str) -> bool {
-        match self.data_type.as_ref().unwrap() {
-            DataType::String => str::ge,
-            DataType::Float => |token: &str, term: &str| compare_float!(token, ge, term),
-            DataType::Integer => |token: &str, term: &str| compare_integer!(token, ge, term),
-            DataType::Date => |token: &str, term: &str| compare_date!(token, ge, term),
-            DataType::Bool => |token: &str, term: &str| token == term,
+        match &self.data_type {
+            Some(DataType::String) => str::ge,
+            Some(DataType::Float) => |token: &str, term: &str| compare_float!(token, ge, term),
+            Some(DataType::Integer) => |token: &str, term: &str| compare_integer!(token, ge, term),
+            Some(DataType::Date) => |token: &str, term: &str| compare_date!(token, ge, term),
+            Some(DataType::Bool) => |token: &str, term: &str| token == term,
+            None => |_, _| false,
         }
     }
 
     pub fn le_func(&self) -> fn(&str, &str) -> bool {
-        match self.data_type.as_ref().unwrap() {
-            DataType::String => str::le,
-            DataType::Float => |token: &str, term: &str| compare_float!(token, le, term),
-            DataType::Integer => |token: &str, term: &str| compare_integer!(token, le, term),
-            DataType::Date => |token: &str, term: &str| compare_date!(token, le, term),
-            DataType::Bool => |token: &str, term: &str| token == term,
+        match &self.data_type {
+            Some(DataType::String) => str::le,
+            Some(DataType::Float) => |token: &str, term: &str| compare_float!(token, le, term),
+            Some(DataType::Integer) => |token: &str, term: &str| compare_integer!(token, le, term),
+            Some(DataType::Date) => |token: &str, term: &str| compare_date!(token, le, term),
+            Some(DataType::Bool) => |token: &str, term: &str| token == term,
+            None => |_, _| false,
         }
     }
 

--- a/test/expected/issue-807.out
+++ b/test/expected/issue-807.out
@@ -1,21 +1,24 @@
 CREATE TABLE issue807 (
     id SERIAL8 NOT NULL PRIMARY KEY,
     name text NOT NULL,
-    testdate date
+    testdate date,
+    testdate_array date[]
 );
 CREATE INDEX idxissue807 ON issue807 USING zombodb ((issue807.*));
 INSERT INTO issue807(name, testdate)
 SELECT 'testrow'||generate_series(1, 100, 1),
        (NOW() - '1 day'::INTERVAL * ROUND(RANDOM() * 100))::date;
+INSERT INTO issue807(name, testdate) VALUES ('null date', NULL);
+INSERT INTO issue807(name, testdate_array) VALUES ('date with null', ARRAY['2022-12-01', NULL]::date[]);
 SELECT count(*)
 FROM issue807
          INNER JOIN LATERAL
     zdb.highlight_document('issue807'::regclass,
                            to_json(issue807),
-                           'testdate >= "2022-12-01"'::TEXT) AS highlights ON true;
+                           'testdate >= "2022-12-01" or testdate_array >= "2022-12-01"'::TEXT) AS highlights ON true;
  count 
 -------
-   100
+   101
 (1 row)
 
 drop table issue807 cascade;

--- a/test/sql/issue-807.sql
+++ b/test/sql/issue-807.sql
@@ -1,20 +1,22 @@
 CREATE TABLE issue807 (
     id SERIAL8 NOT NULL PRIMARY KEY,
     name text NOT NULL,
-    testdate date
+    testdate date,
+    testdate_array date[]
 );
 CREATE INDEX idxissue807 ON issue807 USING zombodb ((issue807.*));
 
 INSERT INTO issue807(name, testdate)
 SELECT 'testrow'||generate_series(1, 100, 1),
        (NOW() - '1 day'::INTERVAL * ROUND(RANDOM() * 100))::date;
-
+INSERT INTO issue807(name, testdate) VALUES ('null date', NULL);
+INSERT INTO issue807(name, testdate_array) VALUES ('date with null', ARRAY['2022-12-01', NULL]::date[]);
 SELECT count(*)
 FROM issue807
          INNER JOIN LATERAL
     zdb.highlight_document('issue807'::regclass,
                            to_json(issue807),
-                           'testdate >= "2022-12-01"'::TEXT) AS highlights ON true;
+                           'testdate >= "2022-12-01" or testdate_array >= "2022-12-01"'::TEXT) AS highlights ON true;
 
 
 drop table issue807 cascade;


### PR DESCRIPTION
This fixes a problem related to the work done in #807 where ZDB would panic with `ERROR:  called Option::unwrap() on a None value` when trying to highlight a NULL value using one of the range operators like `>=` or `<=`.